### PR TITLE
Add configurable summon parameters

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -634,6 +634,9 @@ RULE_REAL(NPC, NPCHealOnGateAmount, 25, "How much the NPC will heal on gate if e
 RULE_BOOL(NPC, AnimalsOpenDoors, true, "Determines or not whether animals open doors or not when they approach them")
 RULE_INT(NPC, MaxRaceID, 732, "Maximum Race ID, RoF2 by default supports up to 732")
 RULE_BOOL(NPC, DisableLastNames, false, "Enable to disable NPC Last Names")
+RULE_BOOL(NPC, SummonTimerScaling, false, "Enable to allow SummonTimer to scale to the maximum value defined by Maximum Summon Timer")
+RULE_INT(NPC, MaximumSummonTimerMs, 30000, "Maximum Summon Timeout for mobs to re-summon a player")
+RULE_INT(NPC, NPCSummonTimer, 6000, "Default Summon Timer for NPCs")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Aggro)
@@ -686,6 +689,8 @@ RULE_INT(Range, ClientPositionUpdates, 300, "Distance in which the own changed p
 RULE_INT(Range, CriticalDamage, 80, "The packet range in which critical hit messages are sent")
 RULE_INT(Range, MobCloseScanDistance, 600, "Close scan distance")
 RULE_INT(Range, MaxDistanceToClickDoors, 100, "Max distance that a client can click a door from (Client says 'You can't reach that' at roughly 25-50 for most doors)")
+RULE_REAL(Range,MaxZSummonOffsetIndoor, 10.00, "Maximum distance on Z Axis to which a player can be summoned indoors")
+RULE_REAL(Range,MaxZSummonOffsetOutdoor, 255.00, "Maximum distance on Z Axis to which a player can be summoned outdoors")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Bots)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4789,6 +4789,7 @@ bool Mob::HateSummon() {
 		return false;
 
 	int summon_level = GetSpecialAbility(SPECATK_SUMMON);
+	int times_summoned;
 	if(summon_level == 1 || summon_level == 2) {
 		if(!GetTarget()) {
 			return false;
@@ -4807,24 +4808,34 @@ bool Mob::HateSummon() {
 
 	// now validate the timer
 	int summon_timer_duration = GetSpecialAbilityParam(SPECATK_SUMMON, 0);
-	summon_timer_duration = summon_timer_duration > 0 ? summon_timer_duration : 6000;
+	summon_timer_duration = summon_timer_duration > RuleI(NPC, NPCSummonTimer) ? summon_timer_duration : RuleI(NPC, NPCSummonTimer);
 	Timer *timer = GetSpecialAbilityTimer(SPECATK_SUMMON);
 	if (!timer)
 	{
+		if (RuleB(NPC, SummonTimerScaling))
+			times_summoned = 1;
 		StartSpecialAbilityTimer(SPECATK_SUMMON, summon_timer_duration);
 	} else {
 		if(!timer->Check())
 			return false;
 
+		if (RuleB(NPC, SummonTimerScaling)) {
+			if (timer && times_summoned >= 1) {
+				++times_summoned;
+				summon_timer_duration += summon_timer_duration * times_summoned;
+			}
+			if (summon_timer_duration >= RuleI(NPC, MaximumSummonTimerMs)) {
+				summon_timer_duration = RuleI(NPC, MaximumSummonTimerMs);
+			}
+		}
 		timer->Start(summon_timer_duration);
 	}
-
+		
 	// get summon target
 	SetTarget(GetHateTop());
 	if(target)
 	{
 		if(summon_level == 1) {
-			entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName() );
 
 			float summoner_zoff = GetZOffset();
 			float summoned_zoff = target->GetZOffset();
@@ -4835,8 +4846,15 @@ bool Mob::HateSummon() {
 
 			// probably should be like half melee range, but we can't get melee range nicely because reasons :)
 			new_pos = target->TryMoveAlong(new_pos, 5.0f, angle);
-
+			if (zone->CanCastOutdoor() == 1 && new_pos.z > RuleR(Range, MaxZSummonOffsetOutdoor))
+			{
+				return false;
+			}
+			if (zone->CanCastOutdoor() == 0 && new_pos.z > RuleR(Range, MaxZSummonOffsetIndoor)) {
+				return false;
+			}
 			if (target->IsClient()) {
+				entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName());
 				target->CastToClient()->MovePC(
 					zone->GetZoneID(),
 					zone->GetInstanceID(),
@@ -4853,7 +4871,7 @@ bool Mob::HateSummon() {
 					target->IsPetOwnerClient()
 				);
 				bool set_new_guard_spot = !(IsNPC() && target_is_client_pet);
-
+				entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName());
 				target->GMMove(
 					new_pos.x,
 					new_pos.y,

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4790,6 +4790,7 @@ bool Mob::HateSummon() {
 
 	int summon_level = GetSpecialAbility(SPECATK_SUMMON);
 	int times_summoned;
+	
 	if(summon_level == 1 || summon_level == 2) {
 		if(!GetTarget()) {
 			return false;
@@ -4812,8 +4813,9 @@ bool Mob::HateSummon() {
 	Timer *timer = GetSpecialAbilityTimer(SPECATK_SUMMON);
 	if (!timer)
 	{
-		if (RuleB(NPC, SummonTimerScaling))
-			times_summoned = 1;
+		if (RuleB(NPC, SummonTimerScaling)) {
+			times_summoned++;
+		}
 		StartSpecialAbilityTimer(SPECATK_SUMMON, summon_timer_duration);
 	} else {
 		if(!timer->Check())
@@ -4821,7 +4823,7 @@ bool Mob::HateSummon() {
 
 		if (RuleB(NPC, SummonTimerScaling)) {
 			if (timer && times_summoned >= 1) {
-				++times_summoned;
+				times_summoned++;
 				summon_timer_duration += summon_timer_duration * times_summoned;
 			}
 			if (summon_timer_duration >= RuleI(NPC, MaximumSummonTimerMs)) {


### PR DESCRIPTION
added configurable summon rules to Mobs.
`RULE_REAL(Range,MaxZSummonOffsetIndoor, 10.00, "Maximum distance on Z Axis to which a player can be summoned indoors") 
RULE_REAL(Range,MaxZSummonOffsetOutdoor, 255.00, "Maximum distance on Z Axis to which a player can be summoned outdoors")
 RULE_BOOL(NPC, SummonTimerScaling, false, "Enable to allow SummonTimer to scale to the maximum value defined by Maximum Summon Timer")
 RULE_INT(NPC, MaximumSummonTimerMs, 30000, "Maximum Summon Timeout for mobs to re-summon a player") RULE_INT(NPC, NPCSummonTimer, 6000, "Default Summon Timer for NPCs")`