### PR TITLE
Various proc-related fixes

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5366,7 +5366,7 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance* inst, uint16 spell_id, Mob* on,
 
 	LogSpells("Entered ExecWeaponProc 3");
 	if (IsClient()) {
-		Mob* new_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, on->GetID()));
+		Mob* new_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, on->GetID(), on));
 		if (new_target) {
 			on = new_target;
 		}
@@ -6362,7 +6362,7 @@ void Mob::TrySympatheticProc(Mob* target, uint32 spell_id)
 		return;
 	}
 
-	Mob* new_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, target->GetID()));
+	Mob* new_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, target->GetID(), target));
 
 	if (new_target) {
 		target = new_target;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5366,9 +5366,14 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance* inst, uint16 spell_id, Mob* on,
 
 	LogSpells("Entered ExecWeaponProc 3");
 	if (IsClient()) {
-		Mob* new_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, on->GetID(), on));
-		if (new_target) {
-			on = new_target;
+		//check implied targetting to redirect stuff
+		uint16 new_targetID = GetSpellImpliedTargetID(spell_id, on->GetID(), on);
+		if(new_targetID == 0) { return; } //this proc was cancelled/interrupted
+		if(new_targetID != on->GetID()) {
+			Mob* new_target = entity_list.GetMob(new_targetID);
+			if (new_target) {
+				on = new_target;
+			}
 		}
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6368,28 +6368,6 @@ void Mob::TrySympatheticProc(Mob* target, uint32 spell_id)
 		target = new_target;
 	}
 
-	if (RuleB(Custom, CombatProcsOnSpellCast)) {
-		std::vector<EQ::ItemInstance*> weapon_selector;
-
-		if (m_inv.GetItem(EQ::invslot::slotPrimary) != nullptr) {
-			weapon_selector.push_back(m_inv.GetItem(EQ::invslot::slotPrimary));
-		}
-
-		if (m_inv.GetItem(EQ::invslot::slotSecondary) != nullptr) {
-			weapon_selector.push_back(m_inv.GetItem(EQ::invslot::slotSecondary));
-		}
-		
-		if (m_inv.GetItem(EQ::invslot::slotRange) != nullptr) {
-			weapon_selector.push_back(m_inv.GetItem(EQ::invslot::slotRange));
-		}
-
-		if (!weapon_selector.empty()) {
-			EQ::ItemInstance* selected_weapon = weapon_selector[zone->random.Roll0(weapon_selector.size() - 1)];
-
-			TryWeaponProc(selected_weapon, selected_weapon->GetItem(), target, spells[spell_id].cast_time);
-		}
-	} 
-
 	const uint16 focus_trigger = GetSympatheticSpellProcID(focus_spell);
 
 	if (!IsValidSpell(focus_trigger)) {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -368,7 +368,7 @@ public:
 	void SendSpellBarDisable();
 	void SendSpellBarEnable(uint16 spellid);
 	void ZeroCastingVars();
-	uint16 GetSpellImpliedTargetID(uint16 spell_id, uint16 target_id);
+	uint16 GetSpellImpliedTargetID(uint16 spell_id, uint16 target_id, Mob* target_mob = nullptr);
 	virtual void SpellProcess();
 	virtual bool CastSpell(uint16 spell_id, uint16 target_id, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, int32 casttime = -1,
 		int32 mana_cost = -1, uint32* oSpellWillFinish = 0, uint32 item_slot = 0xFFFFFFFF,

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -6470,7 +6470,7 @@ bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc
 		}
 
 		if (proc_target) {
-			proc_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, proc_target->GetID()));
+			proc_target = entity_list.GetMob(GetSpellImpliedTargetID(spell_id, proc_target->GetID(), proc_target));
 			
 			if ((proc_target->IsClient() || proc_target->IsPetOwnerClient()) && IsDetrimentalSpell(proc_spellid)) {
 				return false; // Cancel this if, after implied targeting, we are still trying to proc a detrimental ability on a client or client pet

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1789,7 +1789,9 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 		}
 
 		if (RuleB(Custom, CombatProcsOnSpellCast) && IsClient()) {
-			if (IsHealthSpell(spell_id) || IsDamageSpell(spell_id)) {
+			//only proc on nukes or heals; only proc detrimental procs on non-friendlies
+			if ((IsHealthSpell(spell_id) || IsDamageSpell(spell_id)) &&
+				(!IsDetrimentalSpell(spell_id) || (IsDetrimentalSpell(spell_id) && IsAttackAllowed(target, true)))) {
 				std::vector<EQ::ItemInstance*> weapon_selector;
 				Client* c = CastToClient();			
 
@@ -1800,7 +1802,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 				if (c->GetInv().GetItem(EQ::invslot::slotSecondary) && c->GetInv().GetItem(EQ::invslot::slotSecondary)->HasProc()) {
 					weapon_selector.push_back(c->GetInv().GetItem(EQ::invslot::slotSecondary));
 				}
-				
+
 				if (c->GetInv().GetItem(EQ::invslot::slotRange) && c->GetInv().GetItem(EQ::invslot::slotRange)->HasProc()) {
 					weapon_selector.push_back(c->GetInv().GetItem(EQ::invslot::slotRange));
 				}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1806,7 +1806,8 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 				}
 
 				if (!weapon_selector.empty()) {
-					EQ::ItemInstance* selected_weapon = weapon_selector[zone->random.Roll0(weapon_selector.size() - 1)];
+					//I think Roll0 already does max-1, so this was previously never able to pick ranged slot. If crash, revert here.
+					EQ::ItemInstance* selected_weapon = weapon_selector[zone->random.Roll0(weapon_selector.size())];
 					uint16 probability = spells[spell_id].cast_time * RuleI(Custom, CombatProcsOnSpellCastProbability);
 					TryWeaponProc(selected_weapon, selected_weapon->GetItem(), target, IsBardSong(spell_id) ? (probability / 4) : probability);
 				}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -139,7 +139,7 @@ void NPC::SpellProcess()
 	Mob::SpellProcess();
 }
 
-uint16 Mob::GetSpellImpliedTargetID(uint16 spell_id, uint16 target_id) {	
+uint16 Mob::GetSpellImpliedTargetID(uint16 spell_id, uint16 target_id, Mob* target_mob) {	
 	if (IsClient() && RuleB(Spells, UseSpellImpliedTargeting)) {
 		//Shortcut Corpse-Only spells
 		if(spells[spell_id].target_type == ST_Corpse) {
@@ -181,8 +181,10 @@ uint16 Mob::GetSpellImpliedTargetID(uint16 spell_id, uint16 target_id) {
 			}
 		}
 
-		Mob* target_mob = entity_list.GetMob(target_id);
-
+		if(target_mob == nullptr) {
+			target_mob = entity_list.GetMob(target_id);
+		}
+		
 		//Sanity check for NULL
 		if (!target_mob || target_id == 0) {
 			//If beneficial, then go ahead and pass to self


### PR DESCRIPTION
1. Add Corpse check to implied targetting
2. Added optional mob pointer to GetSpellImpliedTargetID
    * used this for implied target redirect in ExecWeaponProc
    * only enters entity list in ExecWeaponProc if the new targetID is different (minor optimization)
3. Removed CombatProcsOnSpellCast from TrySympatheticProc (could cause up to three total procs per spell)
4. Fixed spell weapon proc random range
5. Fixed spell weapon proc detrimentals on non-enemies