### PR TITLE
Remove 1hpiercing restriction for calculating base backstab damage

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -171,7 +171,7 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			// until we get a better inv system for NPCs they get nerfed!
 			if (IsClient()) {
 				auto *inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
-				if (inst && inst->GetItem() && inst->GetItem()->ItemType == EQ::item::ItemType1HPiercing) {
+				if (inst && inst->GetItem()) {
 					base = inst->GetItemBackstabDamage(true);
 					if (!inst->GetItemBackstabDamage()) {
 						base += inst->GetItemWeaponDamage(true);


### PR DESCRIPTION
This removes the 1HPiercing restriction from base damage calculation for backstab weapon damage.

There's logic before this that prevents clients from backstabbing using 1HPiercing as appropriate -- it's okay to just return the weapon damage value here and let it be calculated in `RogueBackstab`