### PR TITLE
Fixes a bug with exp rewards from quests

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -896,7 +896,7 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 	// Check for AA XP Cap
 	int aaexp_cap = RuleI(AA, MaxAAEXPPerKill) * GetConLevelModifierPercent(conlevel) * (GetLevel()/50.0f) * (XPRate / 100.0f);
 
-	if (RuleI(AA, MaxAAEXPPerKill) >= 0 && aaexp > aaexp_cap) {
+	if (exp_source == ExpSource::Kill && RuleI(AA, MaxAAEXPPerKill) >= 0 && aaexp > aaexp_cap) {
 		aaexp = aaexp_cap;
 	}
 


### PR DESCRIPTION
I noticed while working on my Temple of Solusek Ro quests that I wasn't getting any exp message even from quests that had exp rewards configured in the quest scripts. Then I realized I had AA exp set to max and I think I found the bug after digging in a little bit here.

I think that the change here accidentally made it so that quests would no longer reward any AA exp: https://github.com/The-Heroes-Journey-EQEMU/Server/commit/27f796cbed39d335ad896e39f3cc87631ba696a6#diff-214a50474aa7ed005ab50748415739244a24e11a411d83564ed2dcc29f16661a

`GetConLevelModifierPercent`:
https://github.com/The-Heroes-Journey-EQEMU/Server/blob/67b42322ee959ac01a7d63fd467044ddd39433c7/zone/exp.cpp#L222-L247

This returns `0` if there is no `conlevel` which there won't be if the exp is coming from a non-kill source.  This meant that in practice `aaexp` was always being truncated to `0` for quests / tasks / other exp sources other than kills.
https://github.com/The-Heroes-Journey-EQEMU/Server/blob/67b42322ee959ac01a7d63fd467044ddd39433c7/common/eq_constants.h#L1116-L1126