### PR TITLE
Enable up to `RuleI(Combat, MaxProcs)` spell/AA procs rather than proc _attempts_

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5460,8 +5460,9 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 	}
 
 	int16 poison_slot=-1;
+	int procCount = 0;
 
-	for (uint32 i = 0; i < m_max_procs; i++) {
+	for (uint32 i = 0; i < MAX_PROCS; i++) {
 		if (IsPet() && hand != EQ::invslot::slotPrimary) //Pets can only proc spell procs from their primay hand (ie; beastlord pets)
 			continue; // If pets ever can proc from off hand, this will need to change
 
@@ -5500,6 +5501,11 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 						ExecWeaponProc(nullptr, SpellProcs[i].spellID, on, SpellProcs[i].level_override);
 						SetProcLimitTimer(SpellProcs[i].base_spellID, SpellProcs[i].proc_reuse_time, ProcType::MELEE_PROC);
 						CheckNumHitsRemaining(NumHit::OffensiveSpellProcs, 0, SpellProcs[i].base_spellID);
+
+						procCount++;
+						if (procCount >= m_max_procs) {
+							break;
+						}
 					}
 					else {
 						LogCombat("Spell proc [{}] failed to proc [{}] ([{}] percent chance)", i, SpellProcs[i].spellID, chance);
@@ -5520,6 +5526,11 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 						ExecWeaponProc(nullptr, RangedProcs[i].spellID, on);
 						CheckNumHitsRemaining(NumHit::OffensiveSpellProcs, 0, RangedProcs[i].base_spellID);
 						SetProcLimitTimer(RangedProcs[i].base_spellID, RangedProcs[i].proc_reuse_time, ProcType::RANGED_PROC);
+
+						procCount++;
+						if (procCount >= m_max_procs) {
+							break;
+						}
 					}
 					else {
 						LogCombat("Ranged proc [{}] failed to proc [{}] ([{}] percent chance)", i, RangedProcs[i].spellID, chance);
@@ -5530,7 +5541,7 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 	}
 
 	//AA Melee and Ranged Procs
-	if (IsOfClientBot()) {
+	if (IsOfClientBot() && procCount < m_max_procs) {
 		for (int i = 0; i < MAX_AA_PROCS; i += 4) {
 
 			int32 aa_rank_id = 0;
@@ -5565,6 +5576,11 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 						LogCombat("AA proc [{}] procing spell [{}] ([{}] percent chance)", aa_rank_id, aa_spell_id, chance);
 						ExecWeaponProc(nullptr, aa_spell_id, on);
 						SetProcLimitTimer(-aa_rank_id, aa_proc_reuse_timer, proc_type);
+
+						procCount++;
+						if (procCount >= m_max_procs) {
+							break;
+						}
 					}
 					else {
 						LogCombat("AA proc [{}] failed to proc [{}] ([{}] percent chance)", aa_rank_id, aa_spell_id, chance);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -297,7 +297,7 @@ Mob::Mob(
 	m_max_procs = std::min(RuleI(Combat, MaxProcs), max_procs);
 
 	// clear the proc arrays
-	for (int j = 0; j < m_max_procs; j++) {
+	for (int j = 0; j < MAX_PROCS; j++) {
 		PermaProcs[j].spellID             = SPELL_UNKNOWN;
 		PermaProcs[j].chance              = 0;
 		PermaProcs[j].base_spellID        = SPELL_UNKNOWN;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6574,7 +6574,7 @@ bool Mob::IsCombatProc(uint16 spell_id) {
 	/*
 		Procs that originate from casted spells are still limited by SPA 311 (~Kayen confirmed on live 2/4/22)
 	*/
-	for (int i = 0; i < m_max_procs; i++) {
+	for (int i = 0; i < 10; i++) {
 		if (PermaProcs[i].spellID == spell_id ||
 			SpellProcs[i].spellID == spell_id ||
 			RangedProcs[i].spellID == spell_id ||
@@ -6639,7 +6639,7 @@ bool Mob::AddProcToWeapon(uint16 spell_id, bool bPerma, uint16 iChance, uint16 b
 		// or it is poison and no poison procs are currently present.
 		// Find a slot and use it as normal.
 
-		for (i = 0; i < m_max_procs; i++) {
+		for (i = 0; i < 10; i++) {
 			if (!IsValidSpell(SpellProcs[i].spellID)) {
 				SpellProcs[i].spellID = spell_id;
 				SpellProcs[i].chance = iChance;
@@ -6661,7 +6661,7 @@ bool Mob::RemoveProcFromWeapon(uint16 spell_id, bool bAll) {
 		spell_id = SPELL_VAMPIRIC_EMBRACE_OF_SHADOW;
 	}
 
-	for (int i = 0; i < m_max_procs; i++) {
+	for (int i = 0; i < 10; i++) {
 		if (bAll || SpellProcs[i].spellID == spell_id) {
 			SpellProcs[i].spellID = SPELL_UNKNOWN;
 			SpellProcs[i].chance = 0;
@@ -6714,7 +6714,7 @@ bool Mob::AddRangedProc(uint16 spell_id, uint16 iChance, uint16 base_spell_id, u
 		return(false);
 
 	int i;
-	for (i = 0; i < m_max_procs; i++) {
+	for (i = 0; i < 10; i++) {
 		if (!IsValidSpell(RangedProcs[i].spellID)) {
 			RangedProcs[i].spellID = spell_id;
 			RangedProcs[i].chance = iChance;
@@ -6730,7 +6730,7 @@ bool Mob::AddRangedProc(uint16 spell_id, uint16 iChance, uint16 base_spell_id, u
 
 bool Mob::RemoveRangedProc(uint16 spell_id, bool bAll)
 {
-	for (int i = 0; i < m_max_procs; i++) {
+	for (int i = 0; i < 10; i++) {
 		if (bAll || RangedProcs[i].spellID == spell_id) {
 			RangedProcs[i].spellID = SPELL_UNKNOWN;
 			RangedProcs[i].chance = 0;


### PR DESCRIPTION
…c attempts

**None of this is tested / definitely needs to go on dev server to fuck around with / probably has standard egregious typos and syntax errors but the spirit is correct.**

This changes `TrySpellProc` to enable `m_max_procs` proc effects to occur rather than `m_max_procs` proc effects to be _attempted_.

`MAX_PROCS` (and arrays) gets initialized here:
https://github.com/The-Heroes-Journey-EQEMU/Server/blob/e7470278f7f8f5e8e0c90090d9490a0271a1d628/zone/mob.h#L1677-L1681

The max proc values and arrays all get set / reset here:
https://github.com/The-Heroes-Journey-EQEMU/Server/blob/e7470278f7f8f5e8e0c90090d9490a0271a1d628/zone/mob.cpp#L297-L321