### PR TITLE
Fixes a bug with spell crit damage stacking (this will result in a large reduction in spell critical damage for many players and these players will be very upset)

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1385,6 +1385,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				newbon->CriticalSpellChance += base_value;
 			}
 
+			if (limit_value <= 100) {
+				break;
+			}
+
 			int new_limit = newbon->SpellCritDmgIncNoStack + limit_value;
 
 			if (new_limit > RuleI(Custom, AdditiveSpellCritDmgSoftCap)) {

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3061,6 +3061,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 				int new_limit = new_bonus->SpellCritDmgIncNoStack + limit_value;
 
+				if (limit_value <= 100) {
+					break;
+				}
+
 				if (new_limit > RuleI(Custom, AdditiveSpellCritDmgSoftCap)) {
 					int above_limit = new_limit - RuleI(Custom, AdditiveSpellCritDmgSoftCap);
 					new_bonus->SpellCritDmgIncNoStack = RuleI(Custom, AdditiveSpellCritDmgSoftCap) + static_cast<int>(above_limit * RuleR(Custom, AdditiveSpellCritDmgMultiplier));


### PR DESCRIPTION
Players are going to be very upset about this. Do not merge this without talking to Aporia. You can publicly blame it on me -- I'm happy to absorb their anger.

This fixes an inadvertent bug with spell critical damage stacking that was introduced in #67.

The issue here is that many AA, like Spell Casting Fury, Ingenuity, and Fury of Magic use SPA 294 (`SE_CriticalSpellChance`) for their effects.

Even though the _intention_ with these AA is only to increase spell critical strike chance, the AA's ranks all also have a limit value of 100. Before we introduced the ability for SPA 294 critical strike damage effects to stack, this didn't _really_ matter because only the highest effect would apply.

However, now that they stack, these innocuous values are actually very problematic because the values that were intended to be treated as a 0 are instead adding 100 each.  It's _especially_ problematic in the case of Ingenuity because Cata went above and beyond to add special logic to make it only apply to critical strike chance for procs but currently it's also adding a global increase to critical spell damage.

With this change, we'll again treat these 0 mods as a 0 and only increment the spell critical strike damage mod for effects with values over 100 (which are intentionally increasing the critical strike modifier over the base of 100).

Ultimately, this change will bring proc focused builds much more inline with other types of damage dealing builds -- the issue is that a lot of people have already gone pretty deep on these proc based builds.