### PR TITLE
Enables hhe / attack delay reduction to work for bows

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -7026,12 +7026,11 @@ void Client::SetAttackTimer()
 			// rather than the cap ...
 			speed = std::max(speed - GetQuiverHaste(speed), RuleI(Combat, QuiverHasteCap));
 		}
-		else {
-			if (RuleB(Spells, Jun182014HundredHandsRevamp))
-				speed = static_cast<int>(speed + ((hhe / 1000.0f) * speed));
-			else
-				speed = static_cast<int>(speed + ((hhe / 100.0f) * delay));
-		}
+
+		if (RuleB(Spells, Jun182014HundredHandsRevamp))
+			speed = static_cast<int>(speed + ((hhe / 1000.0f) * speed));
+		else
+			speed = static_cast<int>(speed + ((hhe / 100.0f) * delay));
 		TimerToUse->SetAtTrigger(std::max(RuleI(Combat, MinHastedDelay), speed), true, true);
 
 		if (i == EQ::invslot::slotPrimary) {


### PR DESCRIPTION
🤷‍♂️ I've seen some people ask about this / complain about this and I looked into it and it seemed reasonable so here's a PR if you're interested.

This means that the bonus from `SE_HundredHands` / SPA 182 will now also work for bows.  It potentially makes a combination of Monk / Ranger (Way of Steel) or Berserker / Ranger (for war cry) and Cleric / Ranger (Divine Avatar) a little more appealing.


