### PR TITLE
Prevents each arrow from independently proccing when double / triple firing with a bow

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1133,7 +1133,7 @@ bool Client::RangedAttack(Mob* other, bool CanDoubleAttack) {
 	}
 
 	//Shoots projectile and/or applies the archery damage
-	DoArcheryAttackDmg(other, RangeWeapon, Ammo,0,0,0,0,0,0, AmmoItem, ammo_slot);
+	DoArcheryAttackDmg(other, RangeWeapon, Ammo,0,0,0,0,0,0, AmmoItem, ammo_slot, 4.0f, CanDoubleAttack);
 
 	//EndlessQuiver AA base1 = 100% Chance to avoid consumption arrow.
 	int ChanceAvoidConsume = aabonuses.ConsumeProjectile + itembonuses.ConsumeProjectile + spellbonuses.ConsumeProjectile;


### PR DESCRIPTION
Right now, when double / triple attacking with a bow, each arrow the bow fires rolls procs independently.  This means that each time the ranged attack timer elapses with a bow, you can proc up to 18 times (6x from weapon, 12x from spell procs).

This is pretty different from double attacking / triple attacking with a two handed weapon, for example, where each combat round you get one opportunity to proc, regardless of the whether or not your double and triple attack chances succeed. The equivalent combat round for a two handed weapon can proc up to 6 times.

Some random guy on Discord said this behavior wasn't intentional / desired (I don't know if this is accurate):
![image](https://github.com/user-attachments/assets/be352d97-c352-48b1-9c6d-f52531ac7b84)

This fixes that behavior by skipping proc attempts on the arrows fired by successful double and triple bow shots.

`4.0f` here is the default value for the optional `speed` param of `DoArcheryAttackDmg`.