### PR TITLE
Adds support for multiple stacking double riposte skills

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1475,18 +1475,13 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_GiveDoubleRiposte: {
-			// 0=Regular Riposte 1=Skill Attack Riposte 2=Skill
 			if (limit_value == 0) {
-				/*if (newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] < base_value)
-					newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] = base_value;*/
+				// Regular double riposte bonus uses the 0 limit / index as its "skill ID"
 				newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] += base_value;
+			} else if (limit_value > 0) {
+				// Add or update the skill-specific chance
+				newbon->GiveDoubleRiposte[limit_value] += base_value; // limit_value is the Skill ID, base is the chance
 			}
-			// Only for special attacks.
-			else if (limit_value > 0/* && (newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_SKILL_ATK_CHANCE] < base_value)*/) {
-				newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_SKILL_ATK_CHANCE] += base_value;
-				newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_SKILL]            = limit_value;
-			}
-
 			break;
 		}
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -543,7 +543,7 @@ struct StatBonuses {
 	int32	PetAvoidance;						// Pet avoidance chance.
 	int32	CombatStability;					// Melee damage mitigation.
 	int32	DoubleRiposte;						// Chance to double riposte
-	int32	GiveDoubleRiposte[3];				// 0=Regular Chance, 1=Skill Attack Chance, 2=Skill
+	int32	GiveDoubleRiposte[EQ::skills::HIGHEST_SKILL + 1]; // Stores one entry for each possible skill to allow them each to fire independently
 	uint32	RaiseSkillCap[EQ::skills::HIGHEST_SKILL + 1];		// Raise a specific skill cap (base1= value, base2=skill)
 	int32	Ambidexterity;						// Increase chance to duel wield by adding bonus 'skill'.
 	int32	PetMaxHP;							// Increase the max hp of your pet.


### PR DESCRIPTION
***I haven't tested this, you should deploy this to Testy McTestFace (and also it probably won't compile), but, it's probably close to what you actually want.  I just wrote it in the somewhat janky Github editor as usual.***

This updates the logic for `aabonuses.GiveDoubleRiposte` to allow for multiple stacking riposte skills to work together (which can happen when using a Monk and Rogue together, for example).

The existing behavior for GiveDoubleRiposte used a single 3 slot array to store:
0: Base double riposte chance
1: Riposte skill
2: Riposte skill chance

The new behavior uses an array of up to size `HIGHEST_SKILL` to potentially store a percent chance for riposte with every skill (up to 77 which is the highest skill value). We use `0` as the slot for storing the base double riposte chance which should be fine for convenience and clarity.