### PR TITLE
Combine rune effects from active bard songs.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -6615,22 +6615,26 @@ int32 Mob::RuneAbsorb(int64 damage, uint16 type)
 	uint32 buff_max = GetMaxTotalSlots();
 	if (type == SE_Rune) {
 		for (uint32 slot = 0; slot < buff_max; slot++) {
-			if (slot == spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] && spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT] && buffs[slot].melee_rune && IsValidSpell(buffs[slot].spellid)) {
+			bool active_rune = slot == spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] && spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT];
+			bool bard_rune = IsBardSong(buffs[slot].spellid);
+
+			if ((active_rune || bard_rune) && buffs[slot].melee_rune && IsValidSpell(buffs[slot].spellid)) {
 				int melee_rune_left = buffs[slot].melee_rune;
+				LogCombat("Melee Rune - Slot [{}] SpellID [{}] Remaining [{}] Damage [{}]", slot, buffs[slot].spellid, melee_rune_left, damage);
 
 				if (melee_rune_left > damage)
 				{
 					melee_rune_left -= damage;
 					buffs[slot].melee_rune = melee_rune_left;
+
 					return -6;
 				}
-
 				else
 				{
 					if (melee_rune_left > 0)
 						damage -= melee_rune_left;
 
-					if (!TryFadeEffect(slot) && !IsBardSong(buffs[slot].spellid))
+					if (!bard_rune && !TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
 				}
 			}
@@ -6639,21 +6643,26 @@ int32 Mob::RuneAbsorb(int64 damage, uint16 type)
 
 	else {
 		for (uint32 slot = 0; slot < buff_max; slot++) {
-			if (slot == spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] && spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_AMOUNT] && buffs[slot].magic_rune && IsValidSpell(buffs[slot].spellid)) {
+			bool active_rune = slot == spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] && spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_AMOUNT];
+			bool bard_rune = IsBardSong(buffs[slot].spellid);
+
+			if ((active_rune || bard_rune) && buffs[slot].magic_rune && IsValidSpell(buffs[slot].spellid)) {
 				int magic_rune_left = buffs[slot].magic_rune;
+				LogCombat("Magic Rune - Slot [{}] SpellID [{}] Remaining [{}] Damage [{}]", slot, buffs[slot].spellid, magic_rune_left, damage);
+
 				if (magic_rune_left > damage)
 				{
 					magic_rune_left -= damage;
 					buffs[slot].magic_rune = magic_rune_left;
+
 					return 0;
 				}
-
 				else
 				{
 					if (magic_rune_left > 0)
 						damage -= magic_rune_left;
 
-					if (!TryFadeEffect(slot) && !IsBardSong(buffs[slot].spellid))
+					if (!bard_rune && !TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
 				}
 			}

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3720,27 +3720,30 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_Rune:
-
-				if (new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT] && (new_bonus->MeleeRune[SBIndex::RUNE_BUFFSLOT] > buffslot)){
+				if (new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT] && (new_bonus->MeleeRune[SBIndex::RUNE_BUFFSLOT] > buffslot || IsBardSong(new_bonus->MeleeRune[SBIndex::RUNE_SPELLID]))){
 
 					new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT]   = effect_value;
 					new_bonus->MeleeRune[SBIndex::RUNE_BUFFSLOT] = buffslot;
+					new_bonus->MeleeRune[SBIndex::RUNE_SPELLID]  = spell_id;
 				}
 				else if (!new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT]){
 					new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT]   = effect_value;
 					new_bonus->MeleeRune[SBIndex::RUNE_BUFFSLOT] = buffslot;
+					new_bonus->MeleeRune[SBIndex::RUNE_SPELLID]  = spell_id;
 				}
 
 				break;
 
 			case SE_AbsorbMagicAtt:
-				if (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT] && (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] > buffslot)){
+				if (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT] && (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] > buffslot || IsBardSong(new_bonus->AbsorbMagicAtt[SBIndex::RUNE_SPELLID]))){
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT]   = effect_value;
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] = buffslot;
+					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_SPELLID]  = spell_id;
 				}
 				else if (!new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT]){
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT]   = effect_value;
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] = buffslot;
+					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_SPELLID]  = spell_id;
 				}
 				break;
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -462,8 +462,8 @@ struct StatBonuses {
 	int32	ImprovedTaunt[3];					// 0 = Max Level 1 = Aggro modifier 2 = buff slot
 	int8	Root[2];							// The lowest buff slot a root can be found. [0] = Bool if has root [1] = buff slot
 	int32	FrenziedDevastation;				// base1= AArank(used) base2= chance increase spell criticals + all DD spells 2x mana.
-	uint32	AbsorbMagicAtt[2];					// 0 = magic rune value 1 = buff slot
-	uint32	MeleeRune[2];						// 0 = rune value 1 = buff slot
+	uint32	AbsorbMagicAtt[3];					// 0 = magic rune value 1 = buff slot 2 = spell id
+	uint32	MeleeRune[3];						// 0 = rune value 1 = buff slot 2 = spell id
 	bool	NegateIfCombat;						// Bool Drop buff if cast or melee
 	int8	Screech;							// -1 = Will be blocked if another Screech is +(1)
 	int32	AlterNPCLevel;						// amount of lvls +/-
@@ -627,6 +627,7 @@ namespace SBIndex {
 	constexpr uint16 ROOT_BUFFSLOT                          = 1; // SPA 99
 	constexpr uint16 RUNE_AMOUNT                            = 0; // SPA 55
 	constexpr uint16 RUNE_BUFFSLOT                          = 1; // SPA 78
+	constexpr uint16 RUNE_SPELLID                           = 2; // SPA 55,78
 	constexpr uint16 POSITION_BACK							= 0; // SPA 503-506
 	constexpr uint16 POSITION_FRONT							= 1; // SPA 503-506
 	constexpr uint16 PET_RAMPAGE_CHANCE                     = 0; // SPA 464,465


### PR DESCRIPTION
### Original Bug

https://discord.com/channels/1204418766318862356/1312954376700035072

Although the game visually allows up to 3 bard songs with rune effects to stack (Shield of Songs, Nilipus' March of the Wee, Niv's Harmonic) the player does not benefit from the effect of the stacking runes.

This is due to how the original logic determined which rune was 'active' would then swap in the next eligible rune (usually by buff order) when the current one was removed. Since bard songs do not get removed it would never step to the next one to absorb any damage overflow from the first.

Depending on how the songs were applied this could also reduce overall effectiveness of the runes by prioritizing a weaker bard rune before a stronger one.

### Changes

_(bonuses.cpp)_
An additional field was added to track the spell-id of the current 'active' rune effect.  This enables an 'IsBardSong' check to determine if the newly applied rune should become active or not, giving the existing one lower priority if it's a bard song.  Edit: This change is largely necessary in order to get runes on pets to behave similar to the player since pets do not follow the same rules for ordering buffs.

_(attack.cpp)_
The logic for applying the rune effect was then modified to retain the original behavior for non-bard runes but then also treat anything identified as a bard rune as if it is also 'active', while also preventing the bard runes from fading.

### Performance Impacts

StatBonuses structure size increased by 8 bytes.  Increasing memory cost of each 'Mob' by 24 bytes (itembonuses, spellbonuses, aabonuses).

### Class Balance Considerations

This change will not effect the performance of any single bard rune song but will increase overall bard rune strength if they are willing to use multiple spell gems and stack multiple songs.

For full transparency, due to how the original logic worked bard runes were already performing better than expected due to how they did not 'exhaust' themselves in every scenario, particularly when incoming damage exceeded the rune amount.  This behavior was retained because I both lack the context on that behavior and changing it would likely result in an overall nerf, even with the new stacking behavior.

### Testing

Tested locally running THJ server+client using various combinations of normal runes (Rune I/II/etc) and bard runes on both the player and the player's pet (due to slightly different buff behavior on things like pets).