### PR TITLE
[Handin] Fix successive handins

### DIFF
--- a/zone/cli/npc_handins.cpp
+++ b/zone/cli/npc_handins.cpp
@@ -298,7 +298,6 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 						HandinEntry{.item_id = "1007", .count = 1},
 						HandinEntry{.item_id = "1007", .count = 1},
 						HandinEntry{.item_id = "1007", .count = 1},
-						HandinEntry{.item_id = "1007", .count = 1},
 					},
 					.money = {
 						.platinum = 1,
@@ -307,7 +306,7 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 						.copper  = 444,
 					},
 				},
-				.handin_check_result = false,
+				.handin_check_result = true,
 			},
 			TestCase{
 				.description = "Test handing in item of a stack",

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4509,9 +4509,13 @@ bool NPC::CheckHandin(
 		}
 	}
 
+	// if we started the hand-in process, we want to use the hand-in items from the member variable hand-in bucket
 	auto &handin_items = !m_handin_started ? h.items : m_hand_in.items;
 
+	// remove items from the hand-in bucket that were used to fulfill the requirement
 	std::vector<HandinEntry> items_to_remove;
+
+	// check if the hand-in items fulfill the requirement
 	bool items_met = true;
 	if (!handin_items.empty() && !r.items.empty()) {
 		for (const auto &r_item : r.items) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4509,8 +4509,9 @@ bool NPC::CheckHandin(
 		}
 	}
 
+	std::vector<HandinEntry> items_to_remove;
 	bool items_met = true;
-	if (h.items.size() == r.items.size() && !h.items.empty() && !r.items.empty()) {
+	if (!h.items.empty() && !r.items.empty()) {
 		for (const auto &r_item: r.items) {
 			bool      found = false;
 			for (auto &h_item: h.items) {
@@ -4524,6 +4525,7 @@ bool NPC::CheckHandin(
 							h_item.item_id,
 							h_item.count
 						);
+						items_to_remove.push_back(h_item);
 						break;
 					}
 				} else {
@@ -4536,6 +4538,7 @@ bool NPC::CheckHandin(
 							h_item.item_id,
 							h_item.count
 						);
+						items_to_remove.push_back(h_item);
 						break;
 					}
 				}
@@ -4543,66 +4546,64 @@ bool NPC::CheckHandin(
 
 			if (!found) {
 				items_met = false;
+				items_to_remove.clear();
 				break;
 			}
 		}
-	}
-	// if we have items in the hand-in bucket and required items, but the individual counts don't match
-	// say we have 4 individual entries in hand-in but required has one entry for 4 items
-	// we need to check if the required item is in the hand-in bucket 4 times
-	// TestCase{
-	//	.description = "Test handing in 4 non-stacking helmets when 4 are required",
-	//	.hand_in = {
-	//		.items = {
-	//			HandinEntry{.item_id = "29062", .count = 1},
-	//			HandinEntry{.item_id = "29062", .count = 1},
-	//			HandinEntry{.item_id = "29062", .count = 1},
-	//			HandinEntry{.item_id = "29062", .count = 1},
-	//		},
-	//		.money = {},
-	//	},
-	//	.required = {
-	//		.items = {
-	//			HandinEntry{.item_id = "29062", .count = 4},
-	//		},
-	//		.money = {},
-	//	},
-	//	.returned = {
-	//		.items = {
-	//		},
-	//		.money = {},
-	//	},
-	//	.handin_check_result = true,
-	// },
-	else if (!h.items.empty() && !r.items.empty()) {
-		std::unordered_map<std::string, uint16> handin_aggregated;
-		std::unordered_map<std::string, uint16> required_aggregated;
+		// aggregate case
+		// if we have items in the hand-in bucket and required items, but the individual counts don't match
+		// say we have 4 individual entries in hand-in but required has one entry for 4 items
+		// we need to check if the required item is in the hand-in bucket 4 times
+		// TestCase{
+		//	.description = "Test handing in 4 non-stacking helmets when 4 are required",
+		//	.hand_in = {
+		//		.items = {
+		//			HandinEntry{.item_id = "29062", .count = 1},
+		//			HandinEntry{.item_id = "29062", .count = 1},
+		//			HandinEntry{.item_id = "29062", .count = 1},
+		//			HandinEntry{.item_id = "29062", .count = 1},
+		//		},
+		//		.money = {},
+		//	},
+		//	.required = {
+		//		.items = {
+		//			HandinEntry{.item_id = "29062", .count = 4},
+		//		},
+		//		.money = {},
+		//	},
+		//	.returned = {
+		//		.items = {
+		//		},
+		//		.money = {},
+		//	},
+		//	.handin_check_result = true,
+		// },
+		if (!items_met) {
+			std::unordered_map<std::string, uint16> handin_aggregated;
+			std::unordered_map<std::string, uint16> required_aggregated;
 
-		if (!normalize) {
-			// Aggregate counts for hand-in items
-			for (const auto &h_item : h.items) {
-				handin_aggregated[h_item.item_id] += h_item.count;
+			if (!normalize) {
+				// Aggregate counts for hand-in items
+				for (const auto &h_item : h.items) {
+					handin_aggregated[h_item.item_id] += h_item.count;
+				}
+
+				// Aggregate counts for required items
+				for (const auto &r_item : r.items) {
+					required_aggregated[r_item.item_id] += r_item.count;
+				}
+			} else {
+				// Aggregate counts for hand-in items
+				for (const auto &h_item : h.items) {
+					handin_aggregated[std::to_string(Strings::ToInt(h_item.item_id) % 1000000)] += h_item.count;
+				}
+
+				// Aggregate counts for required items
+				for (const auto &r_item : r.items) {
+					required_aggregated[r_item.item_id] += r_item.count;
+				}
 			}
 
-			// Aggregate counts for required items
-			for (const auto &r_item : r.items) {
-				required_aggregated[r_item.item_id] += r_item.count;
-			}
-		} else {
-			// Aggregate counts for hand-in items
-			for (const auto &h_item : h.items) {
-				handin_aggregated[std::to_string(Strings::ToInt(h_item.item_id) % 1000000)] += h_item.count;
-			}
-
-			// Aggregate counts for required items
-			for (const auto &r_item : r.items) {
-				required_aggregated[r_item.item_id] += r_item.count;
-			}
-		}
-
-		if (handin_aggregated.size() != required_aggregated.size()) {
-			items_met = false;
-		} else {
 			// Compare aggregated hand-in and required counts
 			bool met = false;
 			// Check if all required items are present and match exactly
@@ -4612,6 +4613,23 @@ bool NPC::CheckHandin(
 					met = false; // Explicitly set false for clarity
 					break; // No need to continue if one mismatch is found
 				}
+
+				// If we reach here, it means current item matched
+				for (auto &h_item : h.items) {
+					if (normalize) {
+						if ((Strings::ToInt(h_item.item_id) % 1000000) == Strings::ToInt(item_id) && h_item.count == required_count) {
+							met = true;
+							items_to_remove.push_back(h_item);
+							break;
+						}
+					} else {
+						if (h_item.item_id == item_id && h_item.count == required_count) {
+							met = true;
+							items_to_remove.push_back(h_item);
+							break;
+						}
+					}
+				}
 				// If we reach here, it means current item matched
 				met = true;
 			}
@@ -4620,6 +4638,9 @@ bool NPC::CheckHandin(
 
 			if (items_met) {
 				LogNpcHandin("Met aggregate item requirement case");
+			} else {
+				LogNpcHandin("Failed aggregate item requirement case");
+				items_to_remove.clear();
 			}
 		}
 	}
@@ -4665,23 +4686,23 @@ bool NPC::CheckHandin(
 
 	// check if npc is guildmaster
 	if (IsGuildmaster()) {
-		for (const auto &h_item: m_hand_in.items) {
-			if (!h_item.item) {
+		for (const auto &remove_item : items_to_remove) {
+			if (!remove_item.item) {
 				continue;
 			}
 
-			if (!IsDisciplineTome(h_item.item->GetItem())) {
+			if (!IsDisciplineTome(remove_item.item->GetItem())) {
 				continue;
 			}
 
 			if (IsGuildmasterForClient(c)) {
-				c->TrainDiscipline(h_item.item->GetID());
+				c->TrainDiscipline(remove_item.item->GetID());
 				m_hand_in.items.erase(
 					std::remove_if(
 						m_hand_in.items.begin(),
 						m_hand_in.items.end(),
 						[&](const HandinEntry &i) {
-							bool removed = i.item_id == h_item.item_id;
+							bool removed = i.item == remove_item.item;
 							if (removed) {
 								LogNpcHandin(
 									"{} Hand-in success, removing discipline tome [{}] from hand-in bucket",
@@ -4765,15 +4786,13 @@ bool NPC::CheckHandin(
 
 	if (requirement_met) {
 		std::vector<std::string> log_entries = {};
-		for (const auto &h_item : h.items) {
+		for (const auto &remove_item: items_to_remove) {
 			m_hand_in.items.erase(
 				std::remove_if(
 					m_hand_in.items.begin(),
 					m_hand_in.items.end(),
 					[&](const HandinEntry &i) {
-						bool removed = i.item_id == h_item.item_id
-									   && i.count == h_item.count
-									   && i.item->GetSerialNumber() == h_item.item->GetSerialNumber();
+						bool removed = (remove_item.item == i.item);
 						if (removed) {
 							log_entries.emplace_back(
 								fmt::format(

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4844,7 +4844,7 @@ bool NPC::CheckHandin(
 			m_hand_in.money.silver,
 			m_hand_in.money.copper
 		);
-		for (const auto &i: m_hand_in.items) {
+		for (const auto &i: items_to_remove) {
 			LogNpcHandin(
 				"{} Hand-in success, item [{}] ({}) count [{}]",
 				log_handin_prefix,

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -593,10 +593,10 @@ public:
 	bool CanPetTakeItem(const EQ::ItemInstance *inst);
 
 	struct HandinEntry {
-		std::string            item_id            = "0";
-		uint16                 count              = 0;
-		const EQ::ItemInstance *item              = nullptr;
-		bool                   is_multiquest_item = false; // state
+		std::string      item_id            = "0";
+		uint16           count              = 0;
+		EQ::ItemInstance *item              = nullptr;
+		bool             is_multiquest_item = false; // state
 	};
 
 	struct HandinMoney {

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -853,7 +853,7 @@ bool Perl_NPC_CheckHandin(
 
 	for (auto e : items_ref) {
 		const EQ::ItemInstance* i = static_cast<EQ::ItemInstance*>(e);
-		if (!i) {
+		if (!i || !i->GetItem()) {
 			continue;
 		}
 


### PR DESCRIPTION
# Description

This resolves an issue where only exact inputs where allowed during a single hand-in. This change allows for example 4 item's to be handed-in and 1 required item to be checked and met, which plucks off of the stack of handed-in items for each successful hand-in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Below is handing in 4 of the explorer items in Bazaar

![image](https://github.com/user-attachments/assets/bc4f48f7-745a-4c81-95d5-9af9598deda4)

![image](https://github.com/user-attachments/assets/76ecb5f4-e3a2-49f8-8433-7881d2484e44)

Passing test cases

```
ZoneSi |    Info    | StartFileLogs Starting File Log [logs/zone/qrg_version_0_inst_id_0_port_0_10702.log] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | StopShutdownTimer Stopping zone shutdown timer -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins ---------------------------------------- -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins Done booting test zone -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins ---------------------------------------- -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins Spawned NPC [a test npc] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins Spawned client [Noname] -- [qrg] (The Surefall Glade) inst_id [0]
----------------------------------------------------------------------------------------------------
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in failure] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in failure from handing in too many] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money, but not enough] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money, but not enough of any type] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money of all types] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in platinum with items with success] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in platinum with items with failure] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test returning money and items] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test returning money] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in many items of the same required item] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in item of a stack] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in item of a stack but not enough] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in 4 non-stacking helmets when 4 are required] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in Soulfire that has 5 charges and have it count as 1 item] -- [qrg] (The Surefall Glade) inst_id [0]
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
