### PR TITLE
[Handin] Fix Lua edge case on stackable hand-in of 4

### DIFF
--- a/zone/cli/npc_handins.cpp
+++ b/zone/cli/npc_handins.cpp
@@ -13,11 +13,13 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 		return;
 	}
 
+	uint32 break_length = 50;
+
 	RegisterExecutablePlatform(EQEmuExePlatform::ExePlatformZoneSidecar);
 
-	LogInfo("----------------------------------------");
+	LogInfo("{}", Strings::Repeat("-", break_length));
 	LogInfo("Booting test zone for NPC handins");
-	LogInfo("----------------------------------------");
+	LogInfo("{}", Strings::Repeat("-", break_length));
 
 	Zone::Bootup(ZoneID("qrg"), 0, false);
 	zone->StopShutdownTimer();
@@ -25,9 +27,9 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 	entity_list.Process();
 	entity_list.MobProcess();
 
-	LogInfo("----------------------------------------");
-	LogInfo("Done booting test zone");
-	LogInfo("----------------------------------------");
+	LogInfo("{}", Strings::Repeat("-", break_length));
+	LogInfo("> Done booting test zone");
+	LogInfo("{}", Strings::Repeat("-", break_length));
 
 	Client *c       = new Client();
 	auto   npc_type = content_db.LoadNPCTypesData(754008);
@@ -41,8 +43,8 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 
 		entity_list.AddNPC(npc);
 
-		LogInfo("Spawned NPC [{}]", npc->GetCleanName());
-		LogInfo("Spawned client [{}]", c->GetCleanName());
+		LogInfo("> Spawned NPC [{}]", npc->GetCleanName());
+		LogInfo("> Spawned client [{}]", c->GetCleanName());
 
 		struct HandinEntry {
 			std::string            item_id            = "0";
@@ -404,7 +406,7 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 		// turn this on to see debugging output
 		LogSys.log_settings[Logs::NpcHandin].log_to_console = std::getenv("DEBUG") ? 3 : 0;
 
-		std::cout << Strings::Repeat("-", 100) << std::endl;
+		LogInfo("{}", Strings::Repeat("-", break_length));
 
 		for (auto &test_case: test_cases) {
 			hand_ins.clear();


### PR DESCRIPTION
# Description

This was reported in a support thread. This is an edge case because of how the quest is written but my goal is to make all existing quests work regardless and be flexible to all the cases within reason.

**NPC** 

**Tkyar Renlin** in **freeporte**

Example quest

```lua
function event_trade(e)
	local champagne = 0;
	local item_lib = require("items");

	if item_lib.check_turn_in(e.trade, {item1 = 13829,item2 = 13829,item3 = 13829,item4 = 13829}) then
		total_champagne = total_champagne + 4;
		champagne = 4;
	elseif item_lib.check_turn_in(e.trade, {item1 = 13829,item2 = 13829,item3 = 13829}) then
		total_champagne = total_champagne + 3;
		champagne = 3;
	elseif item_lib.check_turn_in(e.trade, {item1 = 13829,item2 = 13829}) then
		total_champagne = total_champagne + 2;
		champagne = 2;
	elseif item_lib.check_turn_in(e.trade, {item1 = 13829}) then
		total_champagne = total_champagne + 1;
		champagne = 1;
	end

	if champagne > 0 then
		repeat
			e.self:Say("Oooh!! That is the taste. My lips are almost loose. Maybe another will do the trick.");
			champagne = champagne - 1;
		until champagne == 0
	end

	if total_champagne >= 4 then
		e.self:Say("Ahh!! That was good. Now where were we?. Oh yes. My [" .. eq.say_link("tell me of zimel",false,"friend Zimel") .. "] is a fellow beggar. He was locked up in the arena. They were going to let him go when the Freeport Militia came for him. Ha!! He is crazy as a troll now. I took this blanket from his cell before I was released. I no longer need it and my guilt has reached its peak. I do not want crazy old Zimel to freeze. Perhaps you can return it to him.");
		e.other:QuestReward(e.self,{exp = 10}); -- Item: Bunker Cell #1 (Zimel's Blanket)
		e.other:SummonFixedItem(12196);
		total_champagne = 0;
	end
	item_lib.return_items(e.self, e.other, e.trade);
end

```

What happens is the successive count logic improperly decrements a single value from the count and leaves it that way for successive hand-ins. 

Instead of leaving the count logic decremented when we didn't actually meet a requirement, we reset the hand-in state. That simply takes care of it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

**Success on handing in 1**

![image](https://github.com/user-attachments/assets/1dead6e9-274b-449b-b00e-fb17a04fd1df)

**Success on handing in 4**

![image](https://github.com/user-attachments/assets/7c837e49-e976-4d2c-a1a6-a1a19c897eba)

**All passing test cases**

```
ZoneSi |    Info    | NpcHandins -------------------------------------------------- -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins > Done booting test zone -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins -------------------------------------------------- -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins > Spawned NPC [a test npc] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins > Spawned client [Noname] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins -------------------------------------------------- -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in failure] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test basic cloth-cap hand-in failure from handing in too many] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money, but not enough] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money, but not enough of any type] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in money of all types] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in platinum with items with success] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in platinum with items with failure] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test returning money and items] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test returning money] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in many items of the same required item] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in item of a stack] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in item of a stack but not enough] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in 4 non-stacking helmets when 4 are required] -- [qrg] (The Surefall Glade) inst_id [0]
ZoneSi |    Info    | NpcHandins PASS [Test handing in Soulfire that has 5 charges and have it count as 1 item] -- [qrg] (The Surefall Glade) inst_id [0]
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
