### PR TITLE
Enable instant cast clickies during bard songs.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9650,7 +9650,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				Bards on live can click items while casting spell gems, it stops that song cast and replaces it with item click cast.
 				Can not click while casting other items.
 			*/
-			if (HasClass(Class::Bard) && IsCasting() && casting_spell_slot < CastingSlot::MaxGems && !RuleB(Custom, MulticlassingEnabled))
+			if (HasClass(Class::Bard) && IsCasting() && casting_spell_slot < CastingSlot::MaxGems && (!RuleB(Custom, MulticlassingEnabled) || IsBardSong(casting_spell_id)))
 			{
 				is_casting_bard_song = true;
 			}
@@ -9811,7 +9811,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						}
 
 
-						if (HasClass(Class::Bard) && !(RuleB(Custom, MulticlassingEnabled))) {
+						if (HasClass(Class::Bard) && (item->CastTime == 0 || !(RuleB(Custom, MulticlassingEnabled)))) {
 							DoBardCastingFromItemClick(is_casting_bard_song, item->CastTime, item->Click.Effect, target_id, CastingSlot::Item, slot_id, item->RecastType, item->RecastDelay);
 						}
 
@@ -9878,7 +9878,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 							CommonBreakInvisible(); // client can't do this for us :(
 						}
 
-						if (HasClass(Class::Bard) && !(RuleB(Custom, MulticlassingEnabled))) {
+						if (HasClass(Class::Bard) && (item->CastTime == 0 || !(RuleB(Custom, MulticlassingEnabled)))) {
 							DoBardCastingFromItemClick(is_casting_bard_song, item->CastTime, item->Click.Effect, target_id, CastingSlot::Item, slot_id, item->RecastType, item->RecastDelay);
 						}
 


### PR DESCRIPTION
Zero expectations as usual.  Feel free to ignore/delete/whatever.

This is mostly a quality of life request.  The main pain point being a bard who uses /melody a lot is when I'm facing a dispelling enemy I'm having to constantly stop and restart the melody to use my instant-class clickies to throw back up my trash buffs.   This causes me to lose my place in the melody and is kinda just tedious overall.  This also fixes a somewhat confusing user experience where clicking an instacast clicky makes the castbar disappear despite not interrupting the spell cast.

Tested on a local akk-stack modified to run the latest code in THJ master branch.

**Test Cases**
- Instacast clickies
  - Effect activates
- Clickies with cast time
  - Effect activates
- Click with charges
  - Charges decrease
- Consumable clicky
  - Item is consumed
- Clicking (instant) during bard song
  - Effect activates, bard song continues casting
- Clicking (instant) during non-bard spell
  - Effect does not activate, spell continues casting
- Clicking (cast time) during bard song
  - Effect does not activate, bard song continues casting
- Clicking (cast time) during non-bard spell
  - Effect does not activate, spell continues casting
- Behaviors when the multi-classing rule is disabled.
  - Click is allowed during casting, does not interrupt if instant, interrupts if non-instant