### PR TITLE
Fixed an issue with buff fading stopping active bard songs.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4912,7 +4912,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 	}
 
 	if (RuleB(Custom, MulticlassingEnabled)) {
-		if (buffs[slot].spellid = bardsong) {
+		if (buffs[slot].spellid == bardsong) {
 			ZeroBardPulseVars();
 		}
 	}


### PR DESCRIPTION
Kinda just stumbled across this one and then worked my way backwards on what problems it was causing.

The biggest problem seemed to be that whenever a buff fades it would stop whatever song the bard was singing.  This is easy to overlook because:

1. It didn't matter for beneficial songs
2. Most people are playing detrimental songs in a melody.
3. Buffs don't fade that often on the server.

Other potential bugs related to this (I've not verified these, just best attempt to understand the code):

- False positives/negatives on whether or not the player still had buffs with num_hits remaining.
- Nimbus effects not removing or removing when they shouldn't have.