### PR TITLE
Skip setting item price for no rent items

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1591,7 +1591,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 				item.StackSize = 1000;
 			}
 
-			if (item.Price == 0 && item.ID % 1000000 != 150000) {
+			if (item.Price == 0 && item.ID % 1000000 != 150000 && !item.NoRent) {
 				float return_value = 0.0f;
 
 				return_value += item.HP / 5.0f;


### PR DESCRIPTION
Skips setting item price if the item is no rent

![image](https://github.com/user-attachments/assets/2b64ac1c-95f6-47eb-bf97-505857b5f8c2)