### PR TITLE
Enable trigger on cast (339) focus effects for AA abilities.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1111,6 +1111,7 @@ RULE_BOOL(Custom,	GroupIncentiveProgram,					false, "Enable GroupIncentiveProgra
 RULE_BOOL(Custom, 	UseAAEXPVeterancy,						false, "Use max AA on any character in account for value of AA:ModernAAScalingAALimit if it is higher")
 RULE_REAL(Custom,	CastedSpellCritBonusRatio, 				1.0, "Multiply casted (Not procs) spells crit ratio by this value")
 RULE_REAL(Custom,	ProcSpellCritBonusRatio, 				1.0, "Multiply proc spells crit ratio by this value")
+RULE_STRING(Custom,	AA339Whitelist,						"16121,16122,16123,16675,16676,16677,30887,30888,30889,aa545", "List of spell/aa ids with trigger on cast effects that will trigger off AA abilities")
 
 RULE_BOOL(Custom,   UseHasteForMeleeSkills, 				true, "Use Haste stat for activated melee skills")
 RULE_REAL(Custom, 	PetWeaponTuningMult, 					0.5, "Value added to weapon ratio for pet weapon usage")

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1560,6 +1560,8 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 				return;
 			}
 
+			TryTriggerOnCastFocusEffect(focusTriggerOnCast, rank->spell, true);
+
 			p_timers.Start(spell_type + pTimerAAStart, timer_duration);
 		}
 		else {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -977,7 +977,7 @@ public:
 	bool PassCharismaCheck(Mob* caster, uint16 spell_id);
 	bool TryDeathSave();
 	bool TryDivineSave();
-	void TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id);
+	void TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id, bool check_whitelist);
 	bool TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc_spellid);
 	bool TrySpellTrigger(Mob *target, uint32 spell_id, int effect);
 	void TryTriggerOnCastRequirement();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1838,7 +1838,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 			}
 		}
 
-		TryTriggerOnCastFocusEffect(focusTriggerOnCast, spell_id);
+		TryTriggerOnCastFocusEffect(focusTriggerOnCast, spell_id, false);
 
 	} else {
 		LogDebug("Spell was not eligible for Sympathetic Procs");
@@ -2678,7 +2678,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 						LogDebug("Adding Extra Pet Target: [{}]", pet->GetCleanName());
 						LogDebug("Setting Override: [{}]", GetEntityVariable("SympProcTargetOverride"));
 						SetEntityVariable("SympProcTargetOverride", std::to_string(pet->GetID()));
-						TryTriggerOnCastFocusEffect(focusTriggerOnCast, spell_id);
+						TryTriggerOnCastFocusEffect(focusTriggerOnCast, spell_id, false);
 					}
 					DeleteEntityVariable("SympProcTargetOverride");
 				}


### PR DESCRIPTION
In 'aa.cpp' around line 2593 the logic for 'casting' an AA spell goes down two different possible paths depending on if the player was a bard or not.  However a change made for THJ causes us to always go into the first branch to give everyone the benefit being able to use AAs while casting spells.

As a result, some interactions that worked in base EQEmu stopped happening in THJ because the 'SpellFinished' code path does not end up calling 'TryTriggerOnCastFocusEffect' while the 'CastSpell' code path does.

The most prominent example of this is the Shaman 'Languid Bite' AA which procs off casting a slow ability.  This does not proc off the shaman AA slow ability on THJ even though the two work together in EQEmu.  This forces Shamans to have to waste a gem slot on a slow spell they don't need just for the purposes of procing this ability.