### PR TITLE
purify body / purify fix

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1199,11 +1199,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			{
 				//Attempt to remove up to base amount of detrimental effects (excluding charm, fear, resurrection, and revival sickness).
 				int purify_count = spells[spell_id].base_value[i];
-				if (purify_count > GetMaxTotalSlots()) {
-					purify_count = GetMaxTotalSlots();
-				}
 
-				for(int slot = 0; slot < purify_count; slot++) {
+				for(int slot = 0; slot < GetMaxTotalSlots() && purify_count > 0; slot++) {
 					if (IsValidSpell(buffs[slot].spellid) && IsDetrimentalSpell(buffs[slot].spellid)){
 
 						if (!IsEffectInSpell(buffs[slot].spellid, SE_Charm) &&
@@ -1215,6 +1212,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							buffs[slot].spellid != SPELL_REVIVAL_SICKNESS)
 						{
 							BuffFadeBySlot(slot);
+							purify_count--;
 						}
 					}
 				}


### PR DESCRIPTION
redirect purify effect pointed at by purify body / purification to max total buff slots instead of it failing to check spell effect > GetMaxTotalSlots as current DB data stops at 20. 

removes any meaningful value from effect 1 in db.

extra ranks with higher spell effect or setting it to 63 there should resolve this for server lifetime alternatively.

a more elaborate fix might do math to quantify beneficial buffs and add that to the count, but given the buff cap of 30 is it meaningfully distinct to just cleanse all of the debuffs instead of a complex function to check 30 slots?