### PR TITLE
Fix implied targeting on instant-cast clickies for bards.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -7494,8 +7494,9 @@ void Mob::DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time
 	}
 	//Instant cast items do not stop bard songs or interrupt casting.
 	else if (CheckItemRaceClassDietyRestrictionsOnCast(item_slot) && DoCastingChecksOnCaster(spell_id, CastingSlot::Item)) {
+		uint16 actual_target = GetSpellImpliedTargetID(spell_id, target_id);
 		int16 DeleteChargeFromSlot = GetItemSlotToConsumeCharge(spell_id, item_slot);
-		if (SpellFinished(spell_id, entity_list.GetMob(target_id), CastingSlot::Item, 0, item_slot)) {
+		if (SpellFinished(spell_id, entity_list.GetMob(actual_target), CastingSlot::Item, 0, item_slot)) {
 			if (IsClient() && DeleteChargeFromSlot >= 0) {
 				CastToClient()->DeleteItemInInventory(DeleteChargeFromSlot, 1, true);
 			}


### PR DESCRIPTION
https://discord.com/channels/1204418766318862356/1336589227022094377

The new codepath we go into for instant-cast clickies on bards was missing the call to 'GetSpellImpliedTargetID'.

Test Cases

Note: Testing this does not work with GM mode enabled since it bypasses various restrictions on casting on other targets.

- Existing test cases for instant-cast clickies continue to work as expected
- Crown of Hatred - Casts on myself when i have an enemy targeted
- Shield of immaculate - Casts on myself when I have an enemy targeted