### PR TITLE
[Fix] Queue Global Buffs and Simplify

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -569,7 +569,7 @@ bool Client::Process() {
 				p->ApplyGlobalBuffs();
 			}
 			GetGlobalBuffTimer()->Disable();
-			Message(Chat::Yellow, "You feel a surge of power. (Global buffs)");
+			Message(Chat::Yellow, "You feel a surge of power. (Global buffs have been applied to you)");
 		}
 
 		if (tic_timer.Check() && !dead) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -563,6 +563,15 @@ bool Client::Process() {
 			}
 		}
 
+		if (GetGlobalBuffTimer()->Check()) {
+			ApplyGlobalBuffs();
+			for (auto &p: GetAllPets()) {
+				p->ApplyGlobalBuffs();
+			}
+			GetGlobalBuffTimer()->Disable();
+			Message(Chat::Yellow, "You feel a surge of power. (Global buffs)");
+		}
+
 		if (tic_timer.Check() && !dead) {
 			CalcMaxHP();
 			CalcMaxMana();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1550,6 +1550,8 @@ public:
 	void ClearDataBucketCache();
 	bool IsGuildmaster() const;
 
+	Timer* GetGlobalBuffTimer() { return &m_global_buff_timer; }
+
 protected:
 	void CommonDamage(Mob* other, int64 &damage, const uint16 spell_id, const EQ::skills::SkillType attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic, eSpecialAttacks specal = eSpecialAttacks::None);
 	static uint16 GetProcID(uint16 spell_id, uint8 effect_index);
@@ -1968,6 +1970,8 @@ protected:
 	MobMovementManager *mMovementManager;
 
 	bool m_invisibility_state = 0;
+
+	Timer m_global_buff_timer;
 
 private:
 	Mob* target;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3200,30 +3200,14 @@ uint32 Zone::AddGlobalBuffTime(uint32 spell_id, uint32 add_duration)
 
 void Zone::ApplyGlobalBuffs()
 {
-	time_t cur_time = Timer::GetTimeSeconds();
-
-	auto all_global_buffs = database.GetGlobalBuffs();
-	std::vector<Mob*> mobs_to_buff;
-
-	for (auto& e : entity_list.GetClientList()) {
-		if (e.second && e.second->IsClient())
-		{
-			auto pets_owned = e.second->GetAllPets();
-			for (auto& client_pet : pets_owned)
-			{
-				mobs_to_buff.push_back(client_pet);
-			}
-
-			mobs_to_buff.push_back(e.second);
-		}
-	}
-
-	for (auto& buff: all_global_buffs)
-	{
-		for (auto& mob : mobs_to_buff)
-		{
-			mob->ApplyGlobalBuff(buff.second.spell_id, buff.second.duration, cur_time);
-		}
+	for (auto &e: entity_list.GetClientList()) {
+		int timer = (int) Mob::RandomTimer(1000, 60000);
+		e.second->GetGlobalBuffTimer()->Start(timer);
+		e.second->Message(
+			Chat::Yellow,
+			"Your senses are tingling. (Global buffs being applied to you in %s)",
+			Strings::ToLower(Strings::SecondsToTime(timer, true)).c_str()
+		);
 	}
 }
 


### PR DESCRIPTION
# Description

Every time global buffs get fired off, the server gets destroyed and World goes down for upwards of 5+ minutes at a time, this creates issues of not being able to log in, prevents zoning and a myriad of other things from working properly.

This change does the following ~

* **Queuing** Queues and fans out global buffs being applied to players once triggered. 
* **Debounce** Debounces global buffs being applied to players once triggered meaning if 10 global buffs were fired off at once, applying global buffs will likely only occur once instead of 10 times for the entire server.
* **Performance** When we applied global buffs at the zone level, multiple nested loops were occurring, this has been simplified down.
* **Messaging** Gives message as feedback to the player that global buffs are pending or have been applied. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested applying multiples at once, only applied once queued timer triggered.

![image](https://github.com/user-attachments/assets/0562adb8-c5f1-4401-b8f0-57dd34f2edd2)

![image](https://github.com/user-attachments/assets/761d35fe-2488-4a36-be4a-6256174baff7)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
