### PR TITLE
Fixes duration for `SE_DivineAura`

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1349,9 +1349,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invulnerability");
 #endif
-				if (spell_id == 4789 && buffslot > -1) { // Touch of the Divine - Divine Save
-					buffs[buffslot].ticsremaining = spells[spell_id].buff_duration;
-				} // Prevent focus/aa buff extension
+				buffs[buffslot].ticsremaining = spells[spell_id].buff_duration;
 
 				SetInvul(true);
 				break;


### PR DESCRIPTION
This fixes a bug that Catapultam asked me to look into an issue where in some cases Divine Aura spell effect durations were longer than expected.