### PR TITLE
Move bard rune message to BardSong filter.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1411,6 +1411,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						filter = FilterPetSpells;
 					}
 
+					if (IsBardSong(spell_id)) {
+						filter = FilterBardSongs;
+					}
+
 					auto caster_name = (filter == FilterPetSpells)
 						? fmt::format("{} (Owner: {})", caster->GetCleanName(), caster->GetOwner()->GetCleanName())
 						: caster->GetCleanName();


### PR DESCRIPTION
https://discord.com/channels/1204418766318862356/1337529995085484083

Moves the 'has shielded himself from 517 points of damage.' message to FilterBardSongs if the rune spell_id is a bard song.

Test Cases
-Bard rune with filter set to 'Show' - Message appears
-Bard rune with filter set to 'Hide' - No message
-Normal rune with filter set to 'Show' - Message appears
-Normal rune with filter set to 'Hide' - Message appears