### PR TITLE
Remove Doppelganger AoE

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8420,7 +8420,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 		auto memmed_spells = GetMemmedSpells();
 		for (int i = 0; i < memmed_spells.size(); i++) {
 			int spell = memmed_spells[i];
-			if (!IsValidSpell(spell) || IsBeneficialSpell(spell)) {
+			if (!IsValidSpell(spell) || IsBeneficialSpell(spell) || !spells[spell].aoe_range < 1 || !spells[spell].aoe_max_targets < 1) {
 				continue;
 			}
 


### PR DESCRIPTION
Dopplegangers still use AoEs, changelog specifies they shouldn't. 

Change iterates to next spell in memmed list if aoe-related fields are ! < 1 to include float on aoe_range 0f and to keep consistency for int aoe_max_targets.

Issue likely due to IsDamageSpell(spell) catching spells that may fall under IsAEDurationSpell(), IsAENukeSpell(), IsPBAENukeSpell() IsAERainNukeSpell() without exclusion.