### PR TITLE
Enables tuning of reflected spell damage from procs.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1116,6 +1116,7 @@ RULE_REAL(Custom,	CastedSpellCritBonusRatio, 				1.0, "Multiply casted (Not proc
 RULE_REAL(Custom,	ProcSpellCritBonusRatio, 				1.0, "Multiply proc spells crit ratio by this value")
 RULE_STRING(Custom, HubZones, 								"151,22", "Hub zones to display in #zoneshard output")
 RULE_STRING(Custom,	AA339Whitelist,							"16121,16122,16123,16675,16676,16677,30887,30888,30889,aa545", "List of spell/aa ids with trigger on cast effects that will trigger off AA abilities")
+RULE_INT(Custom,    ProcReflectPercentage,					50, "The percentage of damage to be dealt if a damaging proc is reflected.")
 
 RULE_BOOL(Custom,   UseHasteForMeleeSkills, 				true, "Use Haste stat for activated melee skills")
 RULE_REAL(Custom, 	PetWeaponTuningMult, 					0.5, "Value added to weapon ratio for pet weapon usage")

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2689,7 +2689,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 				}
 
 				if (isproc) {
-					SpellOnTarget(spell_id, spell_target, 0, true, resist_adjust, true, level_override);
+					SpellOnTarget(spell_id, spell_target, RuleI(Custom, ProcReflectPercentage), true, resist_adjust, true, level_override);
 				} else {
 					if (spells[spell_id].target_type == ST_TargetOptional){
 						if (!TrySpellProjectile(spell_target, spell_id))


### PR DESCRIPTION
# Description

This adds the ability to tune the amount of damage that gets reflected from proc spells.

It adds a new rule (`Custom, ProcReflectPercentage`) which defaults to 50 (50%) that can be used to tune this value.  Currently this value is hardcoded to 0 but with this rule you can tune it to behave however you'd like.

## Type of change
- [x] New feature (non-breaking change which adds functionality)