### PR TITLE
Consume AA.....AA.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1117,6 +1117,7 @@ RULE_REAL(Custom,	ProcSpellCritBonusRatio, 				1.0, "Multiply proc spells crit r
 RULE_STRING(Custom, HubZones, 								"151,22", "Hub zones to display in #zoneshard output")
 RULE_STRING(Custom,	AA339Whitelist,							"16121,16122,16123,16675,16676,16677,30887,30888,30889,aa545", "List of spell/aa ids with trigger on cast effects that will trigger off AA abilities")
 RULE_INT(Custom,    ProcReflectPercentage,					50, "The percentage of damage to be dealt if a damaging proc is reflected.")
+RULE_REAL(Custom,       ConsumeAARatio,                                         2.0, "Number of AAs to consume to produce 1 percent of exp gain")
 
 RULE_BOOL(Custom,   UseHasteForMeleeSkills, 				true, "Use Haste stat for activated melee skills")
 RULE_REAL(Custom, 	PetWeaponTuningMult, 					0.5, "Value added to weapon ratio for pet weapon usage")

--- a/zone/client.h
+++ b/zone/client.h
@@ -741,6 +741,7 @@ public:
 	float GetBaseExpValueForKill(int conlevel, int tier, EQ::ItemInstance* upgrade_item);
 	bool AddItemExperience(EQ::ItemInstance* item, int conlevel);
 	bool ConsumeItemOnCursor();
+	bool ConsumeAAs();
 	void EjectItemFromSlot(int16 slot_id);
 
 	uint64 GetExperienceForKill(Mob *against);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1393,6 +1393,11 @@ bool Perl_Client_ConsumeItemOnCursor(Client* self)
 	return self->ConsumeItemOnCursor();
 }
 
+bool Perl_Client_ConsumeAAs(Client* self)
+{
+	return self->ConsumeAAs();
+}
+
 bool Perl_Client_GrantAlternateAdvancementAbility(Client* self, int aa_id, int points) // @categories Alternative Advancement
 {
 	return self->GrantAlternateAdvancementAbility(aa_id, points);
@@ -3717,6 +3722,7 @@ void perl_register_client()
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int, bool))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("ConsumeItemOnCursor", (bool(*)(Client *))&Perl_Client_ConsumeItemOnCursor);
+	package.add("ConsumeAAs", (bool(*)(Client *))&Perl_Client_ConsumeAAs);
 	package.add("GuildID", &Perl_Client_GuildID);
 	package.add("GuildRank", &Perl_Client_GuildRank);
 	package.add("HasAugmentEquippedByID", &Perl_Client_HasAugmentEquippedByID);


### PR DESCRIPTION
This one might be a bit of a hard sell.   Pretty self-explanatory: converts unspent AA into item exp.

Most of the work was just adding the AA to the database since I guess it's not as simple as just 'select max(id)+1 from aa_ability'.  These are the full set of SQL commands I've prepared for this change:

### Step 1: Set up the IDs to use

I don't know how to automate this step since it appears you need to find an unallocated ID below a certain max value for the client to even recognize the AA.

```
set @aa_id=ENTER UNUSED AA ID HERE;
set @aa_rank_id=ENTER UNUSED AA RANK ID HERE;
set @dbstr_id=ENTER UNUSED DBSTR ID HERE;
set @spell_id=(select max(id)+1 from spells_new);
```

### Step 2: Add entries

This copies existing spells/aa's to use as a starting point and then edits them and inserts them using the ids specified above.

```
begin;
create temporary table tmp select * from spells_new where id=2728;
update tmp set id=@spell_id, name='Consume AA', you_cast='You focus your will upon an item.', cast_time=5000, recovery_time=1500, recast_time=6000, mana=10, icon=2512, memicon=2051, goodEffect=1, targettype=6, basediff=25, skill=14, CastingAnim=43, SpellAffectIndex=4, field142=100, spellanim=305, descnum=id, pvpresistbase=5, pvpresistcalc=101, pvpresistcap=10, spell_category=217, suspendable=1, field221=7, field222=35;
insert into spells_new select * from tmp;
create temporary table tmp2 select * from aa_ranks where id=1388;
update tmp2 set id=@aa_rank_id, upper_hotkey_sid=@dbstr_id, lower_hotkey_sid=@dbstr_id, title_sid=@dbstr_id, desc_sid=@dbstr_id, cost=1, level_req=1, spell=@spell_id, spell_type=20, recast_time=10;
insert into aa_ranks select * from tmp2;
create temporary table tmp3 select * from aa_ability where id=17;
update tmp3 set id=@aa_id, name='Consume AA', first_rank_id=@aa_rank_id;
insert into aa_ability select * from tmp3;
insert into db_str(id, type, value) values(@dbstr_id, 1, 'Consume AA');
insert into db_str(id, type, value) values(@dbstr_id, 2, 'Consume');
insert into db_str(id, type, value) values(@dbstr_id, 3, 'AA');
insert into db_str(id, type, value) values(@dbstr_id, 4, 'Converts remaining unspent alternate advancement points into item experience.');
select tmp.id as spell_id, tmp3.id as aa_id, tmp2.id as aa_rank_id from tmp, tmp2, tmp3;
drop temporary table tmp;
drop temporary table tmp2;
drop temporary table tmp3;
;
```

### Step 3: Verification

Mostly just check for any errors while executing the above commands or anything suspicious like '1000 rows edited/added'.

### Step 4: Finalize

If everything looks good then ```commit;```
Otherwise ```rollback;```

### Testing

- Overflow scenario
  - Item is leveled up to next tier and only the minimum required AA are spent.
- Underflow scenario
  - All points are spent and item gains EXP but does not level up.
- Player has no AA points
  - Error message displayed to player.
- Ratio > 1
  - Each AA point is converted to 1% or less exp.
- Ratio < 1 and > 0
  - Each AA point is converted to > 1% exp.
- Ratio = 0
  - Nothing happens.

### Additional notes

I have the quests changes necessary to hook up the spell but I will need the ID of the spell before I can finalize them and prepare the PR.