### PR TITLE
Prevent `SE_NegateAttacks` from absorbing damage shield damage

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3861,12 +3861,12 @@ int64 Mob::ReduceDamage(int64 damage, bool from_damage_shield)
 					if (!TryFadeEffect(slot))
 						BuffFadeBySlot(slot, true);
 				}
-			}
 
-			if (spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] && (damage > spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT]))
-				damage -= spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT];
-			else
-				return DMG_RUNE;
+				if (spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] && (damage > spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT]))
+					damage -= spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT];
+				else
+					return DMG_RUNE;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

Spell effects using SE_NegateAttacks prevent mobs from receiving damage shield damage but are not removed when absorbing damage shield damage.

This means in practice that you can use effects like these to gain permanent immunity to damage shield effects as long as you aren't getting hit otherwise.

These effects should either not prevent damage shield damage or should be removed by receiving damage shield damage.

Fixes # [(issue)](https://discord.com/channels/1204418766318862356/1340807364970020916)

This just expands the existing `if (!from_damage_shield) {` condition so that it skips removing a charge and also skips preventing damage. The current behavior is that it only skips removing a charge.

I think the bug originally was introduced in this commit https://github.com/The-Heroes-Journey-EQEMU/Server/commit/33bcc8c893cf6c349253ba2c65b548feb18037db which made it so that this effect wouldn't _fade_ when receiving damage from a damage shield (seems okay) but then also allowed it to absorb all damage from damage shields.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)