### PR TITLE
Fixes worn atk cap logic

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -295,14 +295,14 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 			b->AC += item->AC;
 
 			if (item->Attack != 0) {
-				unsigned int cap = RuleI(Character, ItemATKCap);
+				int cap = RuleI(Character, ItemATKCap);
 				cap += itembonuses.ItemATKCap + spellbonuses.ItemATKCap + aabonuses.ItemATKCap;
 
 				if (
 					IsOfClientBotMerc() &&
 					(b->ATK + item->Attack) > cap
 				) {
-					b->ATK = RuleI(Character, ItemATKCap);
+					b->ATK = cap;
 				} else {
 					b->ATK += item->Attack;
 				}


### PR DESCRIPTION
# Description
This updates the worn ATK cap logic to properly snap the capped value back to the cap with AA bonuses considered rather than just the rule value.

Fixes https://discord.com/channels/1204418766318862356/1340106365083058226

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

I couldn't actually reproduce this issue on my server so I wasn't able to test it effectively but I'm pretty sure this is the bug based on the behavior and broken logic