### PR TITLE
Tradeskill fix for fuzzy item matching

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -236,12 +236,13 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 			safe_delete(outapp);
 			database.DeleteWorldContainer(worldo->m_id, zone->GetZoneID());
 		} else { // Delete items in our inventory container...
-			for (uint8 i = EQ::invbag::SLOT_BEGIN; i <= EQ::invbag::SLOT_END; i++) {
+			for (uint8 i = EQ::invbag::SLOT_BEGIN; i < EQ::invtype::WORLD_SIZE; i++) {
 				const EQ::ItemInstance* inst = container->GetItem(i);
 				if (inst) {
 					user->DeleteItemInInventory(EQ::InventoryProfile::CalcSlotId(in_augment->container_slot, i), 0, true);
 				}
 			}
+
 			container->Clear(); // Explicitly mark container as cleared.
 		}
 	}
@@ -1432,22 +1433,20 @@ bool ZoneDatabase::GetTradeRecipe(
 			return false;
 		}
 
-
-
-		const auto item = database.GetItem(inst->GetItem()->ID);
+		const auto item = database.GetItem(inst->GetItem()->OriginalID % 1000000);
 		if (!item) {
-			LogTradeskills("item [{}] not found!", inst->GetItem()->ID);
+			LogTradeskills("item [{}] not found!", inst->GetItem()->OriginalID % 1000000);
 			continue;
 		}
 
 		if (first) {
-			buf2 += fmt::format("{}", (item->ID));
+			buf2 += fmt::format("{}", (item->OriginalID % 1000000));
 			first = false;
 		} else {
-			buf2 += fmt::format(", {}", (item->ID));
+			buf2 += fmt::format(", {}", (item->OriginalID % 1000000));
 		}
 
-		sum += (item->ID);
+		sum += (item->OriginalID % 1000000);
 		count++;
 
 		LogTradeskills(
@@ -1585,13 +1584,10 @@ bool ZoneDatabase::GetTradeRecipe(
 		return GetTradeRecipe(recipe_id, c_type, some_id, c, spec);
 	}
 
-	auto container_itm = database.GetItem(some_id);
-	int container_size = (container && container->GetItem()) ? container->GetItem()->BagSlots : EQ::invtype::WORLD_SIZE;
-
 	for (auto row : results) {
 		int component_count = 0;
 
-		for (uint8 slot_id = EQ::invbag::SLOT_BEGIN; slot_id < container_size; slot_id++) {
+		for (uint8 slot_id = EQ::invbag::SLOT_BEGIN; slot_id < EQ::invtype::WORLD_SIZE; slot_id++) {
 			const auto inst = container->GetItem(slot_id);
 			if (!inst || !inst->GetItem()) {
 				continue;
@@ -1602,12 +1598,12 @@ bool ZoneDatabase::GetTradeRecipe(
 				return false;
 			}
 
-			const auto item = database.GetItem(inst->GetItem()->ID);
+			const auto item = database.GetItem(inst->GetItem()->OriginalID % 1000000);
 			if (!item) {
 				continue;
 			}
 
-			if ((item->ID) == Strings::ToUnsignedInt(row[0])) {
+			if ((item->OriginalID % 1000000) == Strings::ToUnsignedInt(row[0])) {
 				component_count++;
 			}
 


### PR DESCRIPTION
Tradeskill containers with slots > 10 are treated as custom ones which require SPECIFIC items, less than 10 will do fuzzy item version matching