### PR TITLE
Fixes Haste V3 calculation

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2048,7 +2048,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 				else if (effect_value > 0) { // Haste V3 - Stacks and Overcaps
 					if (effect_value > new_bonus->hastetype3) {
-						new_bonus->hastetype3 = effect_value;
+						new_bonus->hastetype3 = effect_value - 100;
 					}
 				}
 				break;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (Why is this change necessary). Please also include relevant motivation and context. List any dependencies that are required for this change.

This fixes a bug where Haste v3 effects were all granting over 100% (25% is the configured maximum) v3 haste.
