### PR TITLE
Fixes an issue where pets are able to get OOC regen while still technically in combat

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -751,7 +751,7 @@ bool NPC::Process()
 			}
 		}
 		else if (GetHP() < GetMaxHP() && GetOwnerID() != 0) {
-			if (!IsEngaged() && !GetOwner()->IsEngaged()) {
+			if (!IsEngaged() && (GetOwner() && !GetOwner()->IsEngaged())) {
 				if (ooc_regen > 0) {
 					pet_regen_bonus = std::max(ooc_regen_calc, npc_hp_regen);
 				}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -751,7 +751,7 @@ bool NPC::Process()
 			}
 		}
 		else if (GetHP() < GetMaxHP() && GetOwnerID() != 0) {
-			if (!IsEngaged()) {
+			if (!IsEngaged() && !GetOwner()->IsEngaged()) {
 				if (ooc_regen > 0) {
 					pet_regen_bonus = std::max(ooc_regen_calc, npc_hp_regen);
 				}


### PR DESCRIPTION
I ran into this while leveling a new character -- I found that I could hit "pet back" and then my pet would start getting the 10% ooc regen every tick.

This is also exploitable in combat by setting pet hold + pet back off to force the pet to get ooc regen while being attacked.