### PR TITLE
Applies `CappedItemBonuses` properly to pets

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -297,7 +297,7 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 
 	auto CalcCappedItemBonus = [&](int currentStat, int bonus, int cap) -> int {
 		int calc_stat = currentStat + CalcItemBonus(bonus);
-		return IsOfClientBotMerc() ? std::min(cap, calc_stat) : calc_stat;
+		return IsOfClientBotMerc() || (IsPet() && IsPetOwnerOfClientBot()) ? std::min(cap, calc_stat) : calc_stat;
 	};
 
 	b->HP += CalcItemBonus(item->HP);


### PR DESCRIPTION
# Description

This fixes a bug where pets were not having the CappedItemBonus rules actually applied because the `CalcCappedItemBonus` function only applies the cap to clients / bots / mercs right now.

With the fix, pets will now also properly be subject to caps