### PR TITLE
Prevent ranged attacking mobs from firing machine guns

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1701,6 +1701,8 @@ void NPC::RangedAttack(Mob *other)
 
 		CommonBreakInvisibleFromCombat();
 	}
+
+	ranged_timer.Start();
 }
 
 void NPC::DoRangedAttackDmg(Mob* other, bool Launch, int16 damage_mod, int16 chance_mod, EQ::skills::SkillType skill, float speed, const char *IDFile)


### PR DESCRIPTION
# Description

Fixes this crazy bug where mobs who are eligible for ranged attacks fire arrows like an insane machine gun.

Pictured:
![image](https://github.com/user-attachments/assets/ac62b0bc-971e-4cc3-b593-47ffcad181aa)
