### PR TITLE
Fixes extremely complicated AA cap logic issue

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -947,7 +947,7 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 	int aa_cap = RuleI(AA, UnusedAAPointCap);
 
 	if (aa_cap >= 0 && aaexp > 0) {
-		if (m_pp.aapoints == aa_cap) {
+		if (m_pp.aapoints >= aa_cap) {
 			MessageString(Chat::Red, AA_CAP);
 			aaexp = 0;
 		}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (Why is this change necessary). Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes an issue where players who already have more than the AA cap are able to continue to earn more AA than the AA cap.

This just prevents earning more, it doesn't reset them below the cap.

