### PR TITLE
Also removes items when clearing loot items

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -931,7 +931,7 @@ void NPC::ClearLootItems()
 	end = m_loot_items.end();
 	for (; cur != end; ++cur) {
 		LootItem *item = *cur;
-		safe_delete(item);
+		RemoveItem(item->item_id);
 	}
 	m_loot_items.clear();
 


### PR DESCRIPTION
# Description

This fixes a discrepancy where calling the `npc:ClearItemList` quest function would remove items from the NPC's loot table but not from their actual inventory.

With this change, we'll both remove all items from their inventory / equipped items and from their loot table when calling the function.

https://github.com/The-Heroes-Journey-EQEMU/Server/blob/38bebf3de4a4cd5311b85df2c99c0a3cd9d9a6bf/zone/loot.cpp#L846-L885