### PR TITLE
Don't allow NPCs to equip augments

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -422,7 +422,7 @@ void NPC::AddLootDropFixed(
 		// If an item can fit into multiple slots we'll pick the last one where
 		// it is an improvement.
 
-		if (!item2->ItemType == EQ::item::ItemTypeAugmentation && !item2->NoPet) {
+		if (!item2->ItemType == EQ::item::ItemTypeAugmentation || !item2->NoPet) {
 			std::vector<int> custom_order = {
 				EQ::invslot::slotPrimary,
 				EQ::invslot::slotSecondary,

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -422,7 +422,7 @@ void NPC::AddLootDropFixed(
 		// If an item can fit into multiple slots we'll pick the last one where
 		// it is an improvement.
 
-		if (!item2->NoPet) {
+		if (!item2->ItemType == EQ::item::ItemTypeAugmentation && !item2->NoPet) {
 			std::vector<int> custom_order = {
 				EQ::invslot::slotPrimary,
 				EQ::invslot::slotSecondary,


### PR DESCRIPTION
# Description

Fixes a bug where NPCs can equip augments in their hands and then can't effectively attack anymore

![image](https://github.com/user-attachments/assets/baf457a9-2710-470f-9b94-b9b5c2684606)
