### PR TITLE
[Performance] Only save changed kill counters

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1073,6 +1073,7 @@ bool Client::Save(uint8 iCommitNow) {
     }
 	if (!entries.empty()) {
 		AccountKillCountsRepository::ReplaceMany(database, entries);
+		loaded_kill_counters = kill_counters;
 	}
 
 	/* Save Character Currency */

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1061,11 +1061,15 @@ bool Client::Save(uint8 iCommitNow) {
 	/* Save Account Kill Counts */
 	std::vector<AccountKillCountsRepository::AccountKillCounts> entries;
     for (const auto& [race_id, count] : kill_counters) {
-        entries.push_back(AccountKillCountsRepository::AccountKillCounts{
-            .account_id = account_id,
-            .race_id = race_id,
-            .count = count
-        });
+		if (loaded_kill_counters[race_id] != count) {
+			entries.push_back(
+				AccountKillCountsRepository::AccountKillCounts{
+					.account_id = account_id,
+					.race_id = race_id,
+					.count = count
+				}
+			);
+		}
     }
 	if (!entries.empty()) {
 		AccountKillCountsRepository::ReplaceMany(database, entries);

--- a/zone/client.h
+++ b/zone/client.h
@@ -2042,6 +2042,7 @@ public:
 	std::string GetAccountBucketExpires(std::string bucket_name);
 	std::string GetAccountBucketRemaining(std::string bucket_name);
 
+	std::map<int, int> loaded_kill_counters;
 	std::map<int, int> kill_counters;
 
 	std::string GetBandolierName(uint8 bandolier_slot);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -545,6 +545,7 @@ void Client::CompleteConnect()
 	for (auto kinfo : kdb) {
 		kill_counters[kinfo.race_id] = kinfo.count;
 	}
+	loaded_kill_counters = kill_counters;
 
 	UpdateWho();
 	client_state = CLIENT_CONNECTED;


### PR DESCRIPTION
# Description

This generates giant queries during frequent saves and adds needless overhead to zones. This only saves what's changed 

## Type of change

- [x] Performance

# Testing

No testing done 

# Checklist

- [ ] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

