### PR TITLE
Add Character:TradeskillUpMinChance rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -156,6 +156,7 @@ RULE_REAL(Character, TradeskillUpPottery, 4.0, "Pottery skillup rate adjustment.
 RULE_REAL(Character, TradeskillUpResearch, 1.0, "Research skillup rate adjustment. Lower is faster")
 RULE_REAL(Character, TradeskillUpTinkering, 2.0, "Tinkering skillup rate adjustment. Lower is faster")
 RULE_REAL(Character, TradeskillUpTailoring, 2.0, "Tailoring skillup rate adjustment. Lower is faster")
+RULE_REAL(Character, TradeskillUpMinChance, 2.5, "Determines the minimum percentage chance to gain a skill increase from a tradeskill.  Cannot go below 2.5")
 RULE_BOOL(Character, MarqueeHPUpdates, false, "Will show health percentage in center of screen if health lesser than 100%")
 RULE_INT(Character, IksarCommonTongue, 95, "Starting value for Common Tongue for Iksars")
 RULE_INT(Character, OgreCommonTongue, 95, "Starting value for Common Tongue for Ogres")

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -20,6 +20,7 @@
 #include "../common/events/player_event_logs.h"
 
 #include <list>
+#include <algorithm>
 
 #ifndef WIN32
 #include <netinet/in.h>	//for htonl
@@ -1347,15 +1348,17 @@ void Client::CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float
 		return;	//not allowed to go higher.
 	uint16 maxskill = MaxSkill(tradeskill);
 
+	float min_skill_up_chance = RuleR(Character, TradeskillUpMinChance);
+	min_skill_up_chance = std::max(min_skill_up_chance, 2.5f);
 	float chance_stage2 = 0;
 
 	//A successfull combine doubles the stage1 chance for an skillup
 	//Some tradeskill are harder than others. See above for more.
 	float chance_stage1 = (bonusstat - stat_modifier) / (skillup_modifier * success_modifier);
+	chance_stage1 = std::max(min_skill_up_chance, chance_stage1);
 
-	//In stage2 the only thing that matters is your current unmodified skill.
-	//If you want to customize here you probbably need to implement your own
-	//formula instead of tweaking the below one.
+	//In stage2 the only thing that matters is your current unmodified skill
+    //and the Character:TradeskillUpMinChance rule.
 	if (chance_stage1 > zone->random.Real(0, 99)) {
 		if (current_raw_skill < 15) {
 			//Always succeed
@@ -1367,6 +1370,7 @@ void Client::CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float
 			//At skill 175, your chance of success falls linearly from 12.5% to 2.5% at skill 300.
 			chance_stage2 = 12.5 - (.08 * (current_raw_skill - 175));
 		}
+		chance_stage2 = std::max(min_skill_up_chance, chance_stage2);
 	}
 
 	if (chance_stage2 > zone->random.Real(0, 99)) {


### PR DESCRIPTION
# Description

This PR adds a new RuleR, TradeskillUpMinChance.  By default it is 2.5%.  If you were to set it to, say, 25%, then every tradeskill combine would give you at least a 25% chance to gain a skill point.

Awhile ago during a Q&A, Aporia said something that alluded to the fact that he's adjusted values in the database and set tradeskills to be as easy as possible, but it's not working.  I believe it's because tradeskills have two checks:

- The "stage1" check, which is influenced by whether you passed or failed, your stats, and the specific tradeskill you are doing.
- The "stage2" check, which is a linear percentage that starts at 92% for skill level 15, and drops down to 2.5% at skill level 299.

This is where "TradeskillUpMinChance" comes into play.  By default, it's 2.5 so it will not affect current behavior.  Setting it to a higher value will increase the chance of skill gain at higher tradeskill levels.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Tested using akkstack.

Clients tested: THJ

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
