### PR TITLE
Fix melee crit msg

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1279,6 +1279,8 @@ RULE_BOOL(Custom,   DisableClearInstanceTimers, false , "BREAK GLASS IN EMERGENC
 RULE_BOOL(Custom,   EnableAccountAltCurrency, false, "Enable account-based alternate currency.")
 RULE_INT(Custom,  	AAConsumeBaseValue, 				50, "Base value for AA consumption")
 
+RULE_REAL(Custom, ScaleAutoAttackByHStr, 0.0f, "Scale auto attack damage by this value. 0.0 to disable.")
+
 // Seasonal
 RULE_INT(Custom,  	EnableSeasonalCharacters, 				0, "Set to Seasonal ID to track for current Seasonal characters, 0 to disable.")
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1207,6 +1207,7 @@ RULE_REAL(Custom,	PetPlacementDistance ,					7.0,  	"Adjust pet formation positi
 RULE_REAL(Custom, 	NonDaggerBackstabMultiplier1H, 			0.75, 	"Multiple Backstabs conducted with not-1hp by this amount")
 RULE_REAL(Custom, 	NonDaggerBackstabMultiplier2H,			0.50, 	"Multiple Backstabs conducted with not-1hp 2h weapon by this amount")
 RULE_BOOL(Custom, 	MonkSkillAttacksAreH2HForProcs, 		true, 	"Read the name")
+RULE_INT(Custom,        DoppelBuffMinDuration,                           150,   "Minimum number of tics remaining on buffs Doppels can copy")
 
 // Item Upgrades
 RULE_BOOL(Custom, 	DoItemUpgrades, 						true, "Retribution item upgrades")

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1745,6 +1745,10 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 		}
 	}
 
+	if (RuleR(Custom, ScaleAutoAttackByHStr)) {
+		my_hit.damage_done += my_hit.damage_done * (RuleR(Custom, ScaleAutoAttackByHStr) * GetHeroicSTR() / 100.0);
+	}
+
 	///////////////////////////////////////////////////////////
 	////// Send Attack Damage
 	///////////////////////////////////////////////////////////

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -6792,6 +6792,8 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 
 	int pct_damage_reduction = defender->GetSkillDmgTaken(hit.skill, opts) + defender->GetPositionalDmgTaken(this);
 
+	LogDebug("Before Damage Reduction: {} After Damage Reduction: {}",
+		hit.damage_done, hit.damage_done + (hit.damage_done * pct_damage_reduction / 100));
 	hit.damage_done += (hit.damage_done * pct_damage_reduction / 100) + defender->GetPositionalDmgTakenAmt(this);
 
 	if (defender->GetShielderID() || defender->spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT]) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1752,21 +1752,38 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	///////////////////////////////////////////////////////////
 	////// Send Attack Damage
 	///////////////////////////////////////////////////////////
-
-	if (my_hit.critical) {
-		/* Normal Critical hit message */
-		entity_list.FilteredMessageCloseString(
-			this, /* Sender */
-			false, /* Skip Sender */
-			RuleI(Range, CriticalDamage),
-			Chat::MeleeCrit, /* Type: 301 */
-			FilterMeleeCrits, /* FilterType: 12 */
-			CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
-			0,
-			GetCleanName(), /* Message1 */
-			itoa(my_hit.damage_done) /* Message2 */
-		);
-	}
+  if (my_hit.critical >= 1) {
+    int critType;
+    int dmg;
+    if (my_hit.critical == 1) { /* Regular Crit */
+      critType = CRITICAL_HIT;
+      dmg = my_hit.damage_done;
+    } 
+    else if (my_hit.critical == 2) { /* Crippling Blow */
+      critType = CRIPPLING_BLOW;
+      dmg = my_hit.damage_done;
+    }
+    else if (my_hit.critical == 3) { /* Slay Undead */
+      int slay_sex = GetGender() == Gender::Female ? FEMALE_SLAYUNDEAD : MALE_SLAYUNDEAD;
+      critType = slay_sex;
+      dmg = my_hit.damage_done;
+    }
+    else if (my_hit.critical == 5) { /* Deadly Strike */
+      critType = DEADLY_STRIKE;
+      dmg = my_hit.damage_done;
+    }
+    entity_list.FilteredMessageCloseString(
+	    this, /* Sender */
+	    false, /* Skip Sender */
+	    RuleI(Range, CriticalDamage),
+	    Chat::MeleeCrit, /* Type: 301 */
+	    FilterMeleeCrits, /* FilterType: 12 */
+	    critType, /* MessageFormat: %1 scores a critical hit! (%2) */
+	    0,
+	    GetCleanName(), /* Message1 */
+	    itoa(dmg) /* Message2 */
+    );
+  }
 
 	other->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, my_hit.skill, true, -1, false, m_specialattacks);
 
@@ -1777,10 +1794,6 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	MeleeLifeTap(my_hit.damage_done);
 
 	CommonBreakInvisibleFromCombat();
-
-	if (GetTarget()) {
-		TriggerDefensiveProcs(other, Hand, true, my_hit.damage_done);
-	}
 
 	if (my_hit.damage_done > 0) {
 		return true;
@@ -5713,19 +5726,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 
 				LogCombatDetail("Final Slayundead damage [{}]", hit.damage_done);
 
-				int slay_sex = GetGender() == Gender::Female ? FEMALE_SLAYUNDEAD : MALE_SLAYUNDEAD;
-
-				entity_list.FilteredMessageCloseString(
-					this, /* Sender */
-					false, /* Skip Sender */
-					RuleI(Range, CriticalDamage),
-					Chat::MeleeCrit, /* Type: 301 */
-					FilterMeleeCrits, /* FilterType: 12 */
-					slay_sex,
-					0,
-					GetCleanName(), /* Message1 */
-					itoa(hit.damage_done) /* Message2 */
-					);
+        hit.critical = 3;
 				return;
 			}
 		}
@@ -5784,14 +5785,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 		hit.damage_done = hit.damage_done + (hit.damage_done * scale);
 		hit.min_damage  = hit.min_damage  + (hit.min_damage + scale);
 
-		entity_list.FilteredMessageClose(this,
-											false,
-											RuleI(Range, CriticalDamage),
-											Chat::MeleeCrit,
-											FilterMeleeCrits,
-											"%s lands a Cleaving Blow! (%i)",
-											GetCleanName(),
-											hit.damage_done + hit.min_damage);
+    hit.critical = 4;
 		return;
 	}
 
@@ -5807,18 +5801,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 					return;
 				}
 				hit.damage_done = hit.damage_done * 200 / 100;
-
-				entity_list.FilteredMessageCloseString(
-					this, /* Sender */
-					false, /* Skip Sender */
-					RuleI(Range, CriticalDamage),
-					Chat::MeleeCrit, /* Type: 301 */
-					FilterMeleeCrits, /* FilterType: 12 */
-					DEADLY_STRIKE, /* MessageFormat: %1 scores a Deadly Strike!(%2) */
-					0,
-					GetCleanName(), /* Message1 */
-					itoa(hit.damage_done + hit.min_damage) /* Message2 */
-				);
+        hit.critical = 5;
 				return;
 			}
 		}
@@ -5836,19 +5819,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 	if (IsBerserk() || berserk) {
 		hit.damage_done += og_damage * 119 / 100;
 		LogCombat("Crip damage [{}]", hit.damage_done);
-
-		entity_list.FilteredMessageCloseString(
-			this, /* Sender */
-			false, /* Skip Sender */
-			RuleI(Range, CriticalDamage),
-			Chat::MeleeCrit, /* Type: 301 */
-			FilterMeleeCrits, /* FilterType: 12 */
-			CRIPPLING_BLOW, /* MessageFormat: %1 lands a Crippling Blow!(%2) */
-			0,
-			GetCleanName(), /* Message1 */
-			itoa(hit.damage_done + hit.min_damage) /* Message2 */
-		);
-
+    hit.critical = 2;
 		// Crippling blows also have a chance to stun
 		// Kayen: Crippling Blow would cause a chance to interrupt for npcs < 55, with a
 		// staggers message.
@@ -5866,7 +5837,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 		return;
 	}
 
-	hit.critical = true;
+	hit.critical = 1;
 }
 
 bool Mob::TryFinishingBlow(Mob *defender, int64 &damage)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1753,18 +1753,20 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	////// Send Attack Damage
 	///////////////////////////////////////////////////////////
 
-	/* Normal Critical hit message */
-	entity_list.FilteredMessageCloseString(
-		this, /* Sender */
-		false, /* Skip Sender */
-		RuleI(Range, CriticalDamage),
-		Chat::MeleeCrit, /* Type: 301 */
-		FilterMeleeCrits, /* FilterType: 12 */
-		CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
-		0,
-		GetCleanName(), /* Message1 */
-		itoa(my_hit.damage_done) /* Message2 */
-	);
+	if (my_hit.critical) {
+		/* Normal Critical hit message */
+		entity_list.FilteredMessageCloseString(
+			this, /* Sender */
+			false, /* Skip Sender */
+			RuleI(Range, CriticalDamage),
+			Chat::MeleeCrit, /* Type: 301 */
+			FilterMeleeCrits, /* FilterType: 12 */
+			CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
+			0,
+			GetCleanName(), /* Message1 */
+			itoa(my_hit.damage_done) /* Message2 */
+		);
+	}
 
 	other->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, my_hit.skill, true, -1, false, m_specialattacks);
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1752,6 +1752,20 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	///////////////////////////////////////////////////////////
 	////// Send Attack Damage
 	///////////////////////////////////////////////////////////
+
+	/* Normal Critical hit message */
+	entity_list.FilteredMessageCloseString(
+		this, /* Sender */
+		false, /* Skip Sender */
+		RuleI(Range, CriticalDamage),
+		Chat::MeleeCrit, /* Type: 301 */
+		FilterMeleeCrits, /* FilterType: 12 */
+		CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
+		0,
+		GetCleanName(), /* Message1 */
+		itoa(my_hit.damage_done) /* Message2 */
+	);
+
 	other->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, my_hit.skill, true, -1, false, m_specialattacks);
 
 	if (CastToClient()->IsDead() || (IsBot() && GetAppearance() == eaDead)) {
@@ -5850,18 +5864,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 		return;
 	}
 
-	/* Normal Critical hit message */
-	entity_list.FilteredMessageCloseString(
-		this, /* Sender */
-		false, /* Skip Sender */
-		RuleI(Range, CriticalDamage),
-		Chat::MeleeCrit, /* Type: 301 */
-		FilterMeleeCrits, /* FilterType: 12 */
-		CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
-		0,
-		GetCleanName(), /* Message1 */
-		itoa(hit.damage_done + hit.min_damage) /* Message2 */
-	);
+	hit.critical = true;
 }
 
 bool Mob::TryFinishingBlow(Mob *defender, int64 &damage)

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -827,6 +827,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->ResistSpellChance += base_value;
 			break;
 		case SE_CriticalHealChance:
+			if (rank.base_ability->id == 214) { // Theft of Life
+				LogDebug("Adding CriticalLifetap [{}]", base_value);
+				newbon->CriticalLifeTapChance += base_value;
+				break;
+			}
 			newbon->CriticalHealChance += base_value;
 			break;
 		case SE_CriticalHealOverTime:

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8644,17 +8644,6 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 		// Do aggro enhancements
 		swarm_pet_npc->SetSpecialAbility(SpecialAbility::AllowedToTank, 1);
 
-		/*
-		swarm_pet_npc->TempName(fmt::format("{}`s_{}_Doppelganger", GetCleanName(),
-												([](int count) {
-													constexpr const char* ordinals[] = {"First", "Second", "Third", "Fourth", "Fifth",
-																						"Sixth", "Seventh", "Eighth", "Ninth", "Tenth"};
-													return ordinals[std::min(count, 9)];
-												})(summon_count-1)
-											).c_str());
-		*/
-
-
 		// Give Client's Buffs to the pet
 		//auto buffs = GetBuffs();
 		for (int buff_idx = 0; buff_idx < GetMaxTotalSlots(); buff_idx++) {
@@ -8719,6 +8708,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 			}
 
 			int spell_type = 0;
+			int recast_time = (spells[spell].recast_time + spells[spell].recovery_time) / 1000;
 
 			if (IsDamageSpell(spell)) {
 				spell_type = SpellType_Nuke;
@@ -8738,6 +8728,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 
 			if (IsEffectInSpell(spell, SE_CurrentHP) && spells[spell].buff_duration > 0) {
 				spell_type = SpellType_DOT;
+				recast_time = -1;
 			}
 
 			if (!spell_type && IsEffectInSpell(SE_MovementSpeed, spell)) {
@@ -8749,7 +8740,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 			}
 
 			if (spell_type && spell) {
-				swarm_pet_npc->AddSpellToNPCList(0, spell, spell_type, -1, (spells[spell].recast_time + spells[spell].recovery_time) / 1000, 0, 0, 0);
+				swarm_pet_npc->AddSpellToNPCList(0, spell, spell_type, -1, recast_time, 0, 0, 0);
 			}
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8646,10 +8646,18 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 
 		// Give Client's Buffs to the pet
 		//auto buffs = GetBuffs();
+		int MinTicDuration    = RuleI(Custom, DoppelBuffMinDuration);
+
 		for (int buff_idx = 0; buff_idx < GetMaxTotalSlots(); buff_idx++) {
-			if (!IsValidSpell(buffs[buff_idx].spellid) || spells[buffs[buff_idx].spellid].short_buff_box) {
+//			if (!IsValidSpell(buffs[buff_idx].spellid) || spells[buffs[buff_idx].spellid].short_buff_box) {
+			if (!IsValidSpell(buffs[buff_idx].spellid)) {
 				continue;
 			}
+			int16 ticsLeft = buffs[buff_idx].ticsremaining;
+			if (ticsLeft < MinTicDuration) {
+				continue;
+			}
+
 			swarm_pet_npc->ApplySpellBuff(buffs[buff_idx].spellid, buffs[buff_idx].ticsremaining);
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8740,7 +8740,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 			}
 
 			if (spell_type && spell) {
-				swarm_pet_npc->AddSpellToNPCList(0, spell, spell_type, -1, recast_time, 0, 0, 0);
+				swarm_pet_npc->AddSpellToNPCList(0, spell, spell_type, -1, -1, 0, 0, 0);
 			}
 		}
 
@@ -8754,6 +8754,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 		entity_list.AddNPC(swarm_pet_npc);
 
 		swarm_pet_npc->CalcBonuses();
+		swarm_pet_npc->SetHP(swarm_pet_npc->GetMaxHP());
 
 		summon_count--;
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5422,8 +5422,7 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 	QueuePacket(outapp);
 	// only wanted to check raid target once
 	// and need con to still be around so, do it here!
-	if (t->IsRaidTarget()) {
-		uint32 color = 0;
+	uint32 color = 0;
 		switch (con->level) {
 			case ConsiderColor::Green:
 				color = 2;
@@ -5449,6 +5448,7 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 				break;
 		}
 
+	if (t->IsRaidTarget()) {
 		if (ClientVersion() <= EQ::versions::ClientVersion::Titanium) {
 			if (color == 6)	{
 				color = 2;
@@ -5456,6 +5456,18 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 		}
 
 		SendColoredText(color, std::string("This creature would take an army to defeat!"));
+	}
+
+	if (t->GetSpecialAbility(SpecialAbility::CharmImmunity)) {
+		SendColoredText(color, std::string("Something about this creature's gaze tells you it cannot be swayed by enchantments!"));
+	}
+
+	if (t->GetSpecialAbility(SpecialAbility::SlowImmunity)) {
+		SendColoredText(color, std::string("This being moves with supernatural grace that defies any attempt to hinder its speed!"));
+	}
+
+	if (t->GetSpecialAbility(SpecialAbility::MesmerizeImmunity)) {
+		SendColoredText(color, std::string("This creature's will is unbreakable - mesmerizing magic would have no effect!"));
 	}
 
 	// this could be done better, but this is only called when you con so w/e

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -702,14 +702,24 @@ bool Client::Process() {
 				}
 			}
 
-			SendBulkStatsUpdate();
 			if (RuleB(Custom, ServerAuthStats) && InZone() && !CAuthorized) {
 				if (CUnauth_tics > 1) {
 					if (GetZoneID() != Zones::BAZAAR) {
 						if (CUnauth_tics >= 11) {
 							zone->SendDiscordMessage("admin", fmt::format("Moving [{}] to Bazaar. Unauthorized Client.", GetCleanName()));
 							const auto safe = zone_store.GetZoneSafeCoordinates(Zones::BAZAAR);
-							MovePC(Zones::BAZAAR, safe.x, safe.y, safe.z, safe.w, 0, ZoneToSafeCoords);
+							auto zone_mode = ZoneSolicited;
+
+							MovePC(
+								Zones::BAZAAR,
+								safe.x,
+								safe.y,
+								safe.z,
+								0.0f,
+								0,
+								zone_mode
+							);
+
 							return false;
 						}
 
@@ -722,6 +732,8 @@ bool Client::Process() {
 				}
 				CUnauth_tics++;
 			}
+
+			SendBulkStatsUpdate();
 		}
 	}
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -413,6 +413,7 @@ struct StatBonuses {
 	int32	SpellCritDmgIncNoStack;				// increase
 	int32	DotCritDmgIncrease;					//i
 	int32	CriticalHealChance;					//i
+	int32   CriticalLifeTapChance;
 	int32	CriticalHealOverTime;				//i
 	int32	CriticalDoTChance;					//i
 	int32	CrippBlowChance;					//

--- a/zone/common.h
+++ b/zone/common.h
@@ -911,7 +911,7 @@ struct DamageHitInfo {
 	int tohit;
 	int hand;
 	EQ::skills::SkillType skill;
-	bool critical = false;
+  int critical = 0;
 };
 
 struct DataBucketCache

--- a/zone/common.h
+++ b/zone/common.h
@@ -911,6 +911,7 @@ struct DamageHitInfo {
 	int tohit;
 	int hand;
 	EQ::skills::SkillType skill;
+	bool critical = false;
 };
 
 struct DataBucketCache

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -368,7 +368,6 @@ int64 Mob::GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiv
 }
 
 int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_buff_tic) {
-
 	if (target == nullptr)
 		return value;
 
@@ -380,7 +379,9 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 		}
 	}
 
-	if (RuleB(Spells, AllowExtraDmgSkill) && RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(spells[spell_id].skill) > 0) {
+	if (RuleB(Spells, AllowExtraDmgSkill) &&
+		RuleB(Character, ItemExtraSkillDamageCalcAsPercent) &&
+		GetSkillDmgAmt(spells[spell_id].skill) > 0) {
 		value *= std::abs(GetSkillDmgAmt(spells[spell_id].skill) / 100);
 	}
 
@@ -395,107 +396,65 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 	if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
 		chance = spells[spell_id].override_crit_chance;
 
-	if (!spells[spell_id].good_effect && chance > 0 && (zone->random.Roll(chance))) {
-		int64 ratio = 200;
-		ratio += GetSharedDotCritDmgIncrease();
-		value = base_value*ratio/100;
-		value += int64(base_value*GetFocusEffect(focusImprovedDamage, spell_id, nullptr, from_buff_tic)/100)*ratio/100;
-		value += int64(base_value*GetFocusEffect(focusImprovedDamage2, spell_id, nullptr, from_buff_tic)/100)*ratio/100;
-		value += int64(base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id, nullptr, from_buff_tic)/100)*ratio/100;
-		value += int64(base_value*GetFocusEffect(focusFcAmplifyMod, spell_id, nullptr, from_buff_tic) / 100)*ratio/100;
-		value += int64(base_value*target->GetVulnerability(this, spell_id, 0, from_buff_tic)/100)*ratio/100;
-		extra_dmg = target->GetFcDamageAmtIncoming(this, spell_id, from_buff_tic) +
-					int64(GetFocusEffect(focusFcDamageAmtCrit, spell_id, nullptr, from_buff_tic)*ratio/100) +
-					GetFocusEffect(focusFcDamageAmt, spell_id, nullptr, from_buff_tic) +
-					GetFocusEffect(focusFcDamageAmt2, spell_id, nullptr, from_buff_tic) +
-					GetFocusEffect(focusFcAmplifyAmt, spell_id, nullptr, from_buff_tic);
+	int64 percent_mod = 100;
+	percent_mod += GetFocusEffect(focusImprovedDamage, spell_id, nullptr, from_buff_tic);
+	percent_mod += GetFocusEffect(focusImprovedDamage2, spell_id, nullptr, from_buff_tic);
+	percent_mod += GetFocusEffect(focusFcDamagePctCrit, spell_id, nullptr, from_buff_tic);
+	percent_mod += GetFocusEffect(focusFcAmplifyMod, spell_id, nullptr, from_buff_tic);
+	percent_mod += target->GetVulnerability(this, spell_id, 0, from_buff_tic);
 
-		if (RuleB(Spells, DOTsScaleWithSpellDmg)) {
-			if (
-				RuleB(Spells, IgnoreSpellDmgLvlRestriction) &&
-				!spells[spell_id].no_heal_damage_item_mod &&
-				GetSharedSpellDamage()
-			) {
-				extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value)*ratio/100;
-			}
-			else if (
-				!spells[spell_id].no_heal_damage_item_mod &&
-				GetSharedSpellDamage() &&
-				GetSpellLevelForCaster(spell_id) >= GetLevel() - 5
-			) {
-				extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value)*ratio/100;
-			}
+	value = base_value * percent_mod / 100;
+
+	extra_dmg = target->GetFcDamageAmtIncoming(this, spell_id, from_buff_tic) +
+				GetFocusEffect(focusFcDamageAmtCrit, spell_id, nullptr, from_buff_tic) +
+				GetFocusEffect(focusFcDamageAmt, spell_id, nullptr, from_buff_tic) +
+				GetFocusEffect(focusFcDamageAmt2, spell_id, nullptr, from_buff_tic) +
+				GetFocusEffect(focusFcAmplifyAmt, spell_id, nullptr, from_buff_tic);
+
+	if (RuleB(Spells, DOTsScaleWithSpellDmg)) {
+		if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) &&
+			!spells[spell_id].no_heal_damage_item_mod &&
+			GetSharedSpellDamage()) {
+			extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value);
 		}
+		else if (!spells[spell_id].no_heal_damage_item_mod &&
+				 GetSharedSpellDamage() &&
+				 GetSpellLevelForCaster(spell_id) >= GetLevel() - 5) {
+			extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value);
+		}
+	}
 
-		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
-			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
+	if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
+		extra_dmg += GetSkillDmgAmt(spells[spell_id].skill);
+	}
+
+	if (extra_dmg) {
+		if (RuleI(Spells, DOTsScaleWithSpellDmgPerTickPercent) > 0) {
+			const int value = RuleI(Spells, DOTsScaleWithSpellDmgPerTickPercent);
+			if (value != 0) {
+				extra_dmg = (extra_dmg * value) / 100;
+			}
 		}
 
 		if (RuleB(Spells, DOTBonusDamageSplitOverDuration)) {
-			if (extra_dmg) {
-				const int duration = CalcBuffDuration(this, target, spell_id);
-				if (duration > 0) {
-					extra_dmg /= duration;
-				}
+			const int duration = CalcBuffDuration(this, target, spell_id);
+			if (duration > 0) {
+				extra_dmg /= duration;
 			}
 		}
-
-		value -= extra_dmg;
 	}
-	else {
 
-		value = base_value;
-		value += base_value*GetFocusEffect(focusImprovedDamage, spell_id, nullptr, from_buff_tic)/100;
-		value += base_value*GetFocusEffect(focusImprovedDamage2, spell_id, nullptr, from_buff_tic)/100;
-		value += base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id, nullptr, from_buff_tic)/100;
-		value += base_value*GetFocusEffect(focusFcAmplifyMod, spell_id, nullptr, from_buff_tic)/100;
-		value += base_value*target->GetVulnerability(this, spell_id, 0, from_buff_tic)/100;
-		extra_dmg = target->GetFcDamageAmtIncoming(this, spell_id, from_buff_tic) +
-					GetFocusEffect(focusFcDamageAmtCrit, spell_id, nullptr, from_buff_tic) +
-					GetFocusEffect(focusFcDamageAmt, spell_id, nullptr, from_buff_tic) +
-					GetFocusEffect(focusFcDamageAmt2, spell_id, nullptr, from_buff_tic) +
-					GetFocusEffect(focusFcAmplifyAmt, spell_id, nullptr, from_buff_tic);
+	value -= extra_dmg;
 
-		if (RuleB(Spells, DOTsScaleWithSpellDmg)) {
-			if (
-				RuleB(Spells, IgnoreSpellDmgLvlRestriction) &&
-				!spells[spell_id].no_heal_damage_item_mod && GetSharedSpellDamage()
-			) {
-				extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value);
-			}
-			else if (
-				!spells[spell_id].no_heal_damage_item_mod && GetSharedSpellDamage() &&
-				GetSpellLevelForCaster(spell_id) >= GetLevel() - 5
-			) {
-				extra_dmg += GetExtraSpellAmt(spell_id, GetSharedSpellDamage(), base_value);
-			}
-		}
+	if (!spells[spell_id].good_effect && chance > 0 && (zone->random.Roll(chance))) {
+		int64 ratio = 200;
+		ratio += GetSharedDotCritDmgIncrease();
 
-		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
-			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill);
-		}
-
-		if (extra_dmg) {
-			if (RuleI(Spells, DOTsScaleWithSpellDmgPerTickPercent) > 0) {
-				const int value = RuleI(Spells, DOTsScaleWithSpellDmgPerTickPercent);
-				if (value != 0) {
-					extra_dmg = (extra_dmg * value) / 100;
-				}
-			}
-
-			if (RuleB(Spells, DOTBonusDamageSplitOverDuration)) {
-				const int duration = CalcBuffDuration(this, target, spell_id);
-				if (duration > 0) {
-					extra_dmg /= duration;
-				}
-			}
-		}
-
-		value -= extra_dmg;
+		value = value * ratio / 100;
 	}
 
 	return value;
-}
+ }
 
 int64 Mob::GetExtraSpellAmt(uint16 spell_id, int64 extra_spell_amt, int64 base_spell_dmg)
 {
@@ -575,6 +534,10 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 
 	if (spells[spell_id].buff_duration < 1) {
 		critical_chance += GetSharedCriticalHealChance();
+
+		if (lifetap) {
+			critical_chance += aabonuses.CriticalLifeTapChance + spellbonuses.CriticalLifeTapChance;
+		}
 
 		if (spellbonuses.CriticalHealDecay) {
 			critical_chance += GetDecayEffectValue(spell_id, SE_CriticalHealDecay);

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -451,10 +451,65 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 		ratio += GetSharedDotCritDmgIncrease();
 
 		value = value * ratio / 100;
+
+		// Generate flavorful message based on resist type
+		std::string crit_message;
+		std::string self_message;
+
+		switch(spells[spell_id].resist_type) {
+			case RESIST_FIRE:
+				crit_message = fmt::format("{}'s fiery affliction consumes {} with devastating intensity! ({}) ({})",
+										 GetCleanName(), target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				self_message = fmt::format("Your fiery affliction rages out of control upon {}! ({}) ({})",
+										 target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				break;
+
+			case RESIST_COLD:
+				crit_message = fmt::format("{}'s freezing affliction bites deep into {}, chilling to the bone! ({}) ({})",
+										 GetCleanName(), target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				self_message = fmt::format("Your freezing affliction penetrates deep into {}! ({}) ({})",
+										 target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				break;
+
+			case RESIST_POISON:
+				crit_message = fmt::format("{}'s toxic affliction courses through {}'s veins with lethal potency! ({}) ({})",
+										 GetCleanName(), target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				self_message = fmt::format("Your toxic affliction reaches critical toxicity in {}! ({}) ({})",
+										 target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				break;
+
+			case RESIST_DISEASE:
+				crit_message = fmt::format("{}'s vile affliction ravages {} with virulent force! ({}) ({})",
+										 GetCleanName(), target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				self_message = fmt::format("Your vile affliction ravages {} with exceptional virulence! ({}) ({})",
+										 target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				break;
+
+			case RESIST_MAGIC:
+			default:
+				crit_message = fmt::format("{}'s arcane affliction tears through {} with exceptional power! ({}) ({})",
+										 GetCleanName(), target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				self_message = fmt::format("Your arcane affliction tears through {} with critical force! ({}) ({})",
+										 target->GetCleanName(), std::abs(value), spells[spell_id].name);
+				break;
+		}
+
+		entity_list.FilteredMessageClose(
+			this,
+			true,
+			RuleI(Range, SpellMessages),
+			Chat::SpellCrit,
+			FilterSpellCrits,
+			crit_message.c_str()
+		);
+
+		if (IsClient()) {
+			Message(Chat::SpellCrit, self_message.c_str());
+		}
 	}
 
 	return value;
- }
+}
 
 int64 Mob::GetExtraSpellAmt(uint16 spell_id, int64 extra_spell_amt, int64 base_spell_dmg)
 {

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3659,7 +3659,7 @@ int64_t Client::GetStatEntryValue(StatEntry label)
 			return (GetSharedSpellCritDmgIncrease() + GetSharedSpellCritDmgIncNoStack());
 		}
 		case statHealCritRate: {
-			return GetSharedCriticalHealChance();
+			return GetSharedCriticalHealChance() + 200;
 		}
 		case statHoTCritRate: {
 			return GetSharedCriticalHealOverTime();

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -90,6 +90,21 @@ void Lua_NPC::RemoveItem(int item_id, int quantity, int slot) {
 	self->RemoveItem(item_id, quantity, slot);
 }
 
+void Lua_NPC::RemoveItemByPercent(float percent) {
+    Lua_Safe_Call_Void();
+    self->RemoveItemByPercent(percent, /*min=*/1, /*max=*/-1);
+}
+
+void Lua_NPC::RemoveItemByPercent(float percent, int min_delete) {
+    Lua_Safe_Call_Void();
+    self->RemoveItemByPercent(percent, min_delete, /*max=*/-1);
+}
+
+void Lua_NPC::RemoveItemByPercent(float percent, int min_delete, int max_delete) {
+    Lua_Safe_Call_Void();
+    self->RemoveItemByPercent(percent, min_delete, max_delete);
+}
+
 void Lua_NPC::ClearLootItems() {
 	Lua_Safe_Call_Void();
 	self->ClearLootItems();
@@ -1066,6 +1081,9 @@ luabind::scope lua_register_npc() {
 	.def("RemoveItem", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveItem)
 	.def("RemoveItem", (void(Lua_NPC::*)(int,int))&Lua_NPC::RemoveItem)
 	.def("RemoveItem", (void(Lua_NPC::*)(int,int,int))&Lua_NPC::RemoveItem)
+        .def("RemoveItemByPercent", (void(Lua_NPC::*)(float))&Lua_NPC::RemoveItemByPercent)
+        .def("RemoveItemByPercent", (void(Lua_NPC::*)(float, int))&Lua_NPC::RemoveItemByPercent)
+        .def("RemoveItemByPercent", (void(Lua_NPC::*)(float, int, int))&Lua_NPC::RemoveItemByPercent)
 	.def("ResumeWandering", (void(Lua_NPC::*)(void))&Lua_NPC::ResumeWandering)
 	.def("ReturnHandinItems", (void(Lua_NPC::*)(Lua_Client))&Lua_NPC::ReturnHandinItems)
 	.def("SaveGuardSpot", (void(Lua_NPC::*)(void))&Lua_NPC::SaveGuardSpot)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -46,6 +46,9 @@ public:
 	void RemoveItem(int item_id);
 	void RemoveItem(int item_id, int quantity);
 	void RemoveItem(int item_id, int quantity, int slot);
+	void RemoveItemByPercent(float percent, int min_delete = 1, int max_delete = -1);
+        void RemoveItemByPercent(float percent, int min_delete = 1);
+        void RemoveItemByPercent(float percent);
 	void ClearLootItems();
 	void AddLootCash(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
 	void RemoveLootCash();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1391,7 +1391,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	ns->spawn.IsMercenary = IsMerc() ? 1 : 0;
 	ns->spawn.targetable_with_hotkey = no_target_hotkey ? 0 : 1; // opposite logic!
 	ns->spawn.untargetable = IsTargetable();
-	
+
 	ns->spawn.petOwnerId	= ownerid;
 
 	ns->spawn.haircolor = haircolor;
@@ -6250,6 +6250,13 @@ int32 Mob::GetSkillDmgTaken(const EQ::skills::SkillType skill_used, ExtraAttackO
 
 	if(skilldmg_mod < -100)
 		skilldmg_mod = -100;
+
+	if (skill_used == EQ::skills::SkillArchery) {
+		LogDebug(
+			"Mob::GetSkillDmgTaken: Archery skill damage modifier: {}",
+			skilldmg_mod
+		);
+	}
 
 	return skilldmg_mod;
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <string>
 #include <utility>
+#include <cmath>
 
 #ifdef _WINDOWS
 #define snprintf	_snprintf
@@ -1728,6 +1729,51 @@ uint32 NPC::GetMaxDamage(uint8 tlevel)
 	return dmg;
 }
 
+void NPC::RemoveItemByPercent(float percent, int min_delete, int max_delete) {
+    percent = std::max(0.0f, std::min(1.0f, percent));
+
+    std::vector<LootItem*> items;
+    items.reserve(m_loot_items.size());
+    for (LootItem* ptr : m_loot_items) {
+        if (ptr && ptr->item_id)
+            items.push_back(ptr);
+    }
+
+    if (items.empty() || percent <= 0.0f)
+        return;
+
+    for (size_t i = items.size() - 1; i > 0; --i) {
+        int j = zone->random.Int(0, static_cast<int>(i));
+        std::swap(items[i], items[j]);
+    }
+
+    size_t total  = items.size();
+    size_t target = static_cast<size_t>(std::floor(total * percent));
+    if (percent > 0.0f && target < static_cast<size_t>(min_delete))
+        target = static_cast<size_t>(min_delete);
+    if (max_delete >= 0 && target > static_cast<size_t>(max_delete))
+        target = static_cast<size_t>(max_delete);
+    if (target > total)
+        target = total;
+
+    size_t removed = 0;
+    for (auto ptr : items) {
+        if (removed >= target)
+            break;
+
+        uint32_t item_id = ptr->item_id;
+
+        for (auto cur = m_loot_items.begin(); cur != m_loot_items.end(); ++cur) {
+            LootItem* citem = *cur;
+            if (citem->item_id == item_id) {
+                RemoveItem(item_id);
+                ++removed;
+                break;
+            }
+        }
+    }
+}
+
 void NPC::PickPocket(Client* thief)
 {
 	thief->CheckIncreaseSkill(EQ::skills::SkillPickPockets, nullptr, 5);
@@ -1772,6 +1818,7 @@ void NPC::PickPocket(Client* thief)
 
 			loot_selection.emplace_back(std::make_pair(item_test, ((item_test->Stackable) ? (1) : (item_iter->charges))));
 		}
+
 		if (loot_selection.empty()) {
 			steal_item = false;
 			break;

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -224,6 +224,7 @@ public:
 	void AddLootTable(uint32 loottable_id, bool is_global = false);
 	void AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop);
 	void CheckGlobalLootTables();
+	void RemoveItemByPercent(float percent, int min_delete = 1, int max_delete = -1);
 	void RemoveItem(uint32 item_id, uint16 quantity = 0, uint16 slot = 0);
 	void CheckTrivialMinMaxLevelDrop(Mob *killer);
 	void ClearLootItems();

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -86,6 +86,24 @@ void Perl_NPC_RemoveItem(NPC* self, uint32 item_id, uint16 quantity, uint16 slot
 	self->RemoveItem(item_id, quantity, slot_id);
 }
 
+void Perl_NPC_RemoveItemByPercent(NPC* self, float percent) // @categories Inventory and Items
+{
+    self->RemoveItemByPercent(percent);
+}
+
+
+void Perl_NPC_RemoveItemByPercent(NPC* self, float percent, int min_delete) // @categories Inventory and Items 
+{
+    self->RemoveItemByPercent(percent, min_delete);
+}
+
+
+void Perl_NPC_RemoveItemByPercent(NPC* self, float percent, int min_delete, int max_delete) // @categories Inventory and Items  
+{
+    self->RemoveItemByPercent(percent, min_delete, max_delete);
+}
+
+
 void Perl_NPC_ClearLootItems(NPC* self) // @categories Inventory and Items
 {
 	self->ClearLootItems();
@@ -1011,6 +1029,9 @@ void perl_register_npc()
 	package.add("RemoveItem", (void(*)(NPC*, uint32))&Perl_NPC_RemoveItem);
 	package.add("RemoveItem", (void(*)(NPC*, uint32, uint16))&Perl_NPC_RemoveItem);
 	package.add("RemoveItem", (void(*)(NPC*, uint32, uint16, uint16))&Perl_NPC_RemoveItem);
+ 	package.add("RemoveItemByPercent", (void(*)(NPC*, float))&Perl_NPC_RemoveItemByPercent);
+        package.add("RemoveItemByPercent", (void(*)(NPC*, float, int))&Perl_NPC_RemoveItemByPercent);
+        package.add("RemoveItemByPercent", (void(*)(NPC*, float, int, int))&Perl_NPC_RemoveItemByPercent);
 	package.add("RemoveMeleeProc", &Perl_NPC_RemoveMeleeProc);
 	package.add("RemoveRangedProc", &Perl_NPC_RemoveRangedProc);
 	package.add("ResumeWandering", &Perl_NPC_ResumeWandering);

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -494,7 +494,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 	// These two are not subject to the combat ability timer, as they
 	// allready do their checking in conjunction with the attack timer
 	// throwing weapons
-	if (ca_atk->m_atk == EQ::invslot::slotRange) {
+	if (ca_atk->m_atk == EQ::invslot::slotRange && ranged_timer.Check(false)) {
 		if (GetAttackMode() == AttackMode::RANGED) {
 			return;
 		}

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -36,33 +36,25 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 {
 	int base = EQ::skills::GetBaseDamage(skill);
 	auto skill_level = GetSkill(skill);
+	bool is_client_or_client_pet = IsClient() || (IsPetOwnerClient() && IsNPC());
+
 	switch (skill) {
 		case EQ::skills::SkillDragonPunch:
 		case EQ::skills::SkillEagleStrike:
 		case EQ::skills::SkillTigerClaw:
-			if (skill_level >= 25) {
-				base++;
-			}
-
-			if (skill_level >= 75) {
-				base++;
-			}
-
-			if (skill_level >= 125) {
-				base++;
-			}
-
-			if (skill_level >= 175) {
-				base++;
-			}
+			// Skill threshold bonuses
+			if (skill_level >= 25)  base++;
+			if (skill_level >= 75)  base++;
+			if (skill_level >= 125) base++;
+			if (skill_level >= 175) base++;
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				base *= std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return base;
+
 		case EQ::skills::SkillFrenzy:
-			if (IsClient() && CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary)) {
+			if (is_client_or_client_pet && GetInv().GetItem(EQ::invslot::slotPrimary)) {
 				if (GetLevel() > 15) {
 					base += GetLevel() - 15;
 				}
@@ -71,29 +63,23 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 					base = 23;
 				}
 
-				if (GetLevel() > 50) {
-					base += 2;
-				}
-
-				if (GetLevel() > 54) {
-					base++;
-				}
-
-				if (GetLevel() > 59) {
-					base++;
-				}
+				// Level-based bonuses
+				if (GetLevel() > 50) base += 2;
+				if (GetLevel() > 54) base++;
+				if (GetLevel() > 59) base++;
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				base *= std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return base;
+
 		case EQ::skills::SkillFlyingKick: {
 			float skill_bonus = skill_level / 9.0f;
-			float ac_bonus    = 0.0f;
-			if (IsClient()) {
-				auto inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotFeet);
+			float ac_bonus = 0.0f;
+
+			if (is_client_or_client_pet) {
+				auto inst = GetInv().GetItem(EQ::invslot::slotFeet);
 				if (inst) {
 					ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 				}
@@ -106,47 +92,44 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return static_cast<int>(ac_bonus + skill_bonus);
 		}
+
 		case EQ::skills::SkillKick:
 		case EQ::skills::SkillRoundKick: {
-			// there is some base *= 4 case in here?
 			float skill_bonus = skill_level / 10.0f;
-			float ac_bonus    = 0.0f;
-			if (IsClient()) {
-				auto inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotFeet);
+			float ac_bonus = 0.0f;
+
+			if (is_client_or_client_pet) {
+				auto inst = GetInv().GetItem(EQ::invslot::slotFeet);
 				if (inst) {
 					ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 				}
 			}
 
-			if (skill_level >= 75) {
-				base++;
-			}
-
-			if (skill_level >= 175) {
-				base++;
-			}
+			// Skill threshold bonuses
+			if (skill_level >= 75)  base++;
+			if (skill_level >= 175) base++;
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return static_cast<int>(ac_bonus + skill_bonus);
 		}
+
 		case EQ::skills::SkillBash: {
-			float                  skill_bonus = skill_level / 10.0f;
-			float                  ac_bonus    = 0.0f;
-			const EQ::ItemInstance *inst       = nullptr;
-			if (IsClient()) {
+			float skill_bonus = skill_level / 10.0f;
+			float ac_bonus = 0.0f;
+			const EQ::ItemInstance *inst = nullptr;
+
+			if (is_client_or_client_pet) {
 				if (HasShieldEquipped()) {
-					inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotSecondary);
+					inst = GetInv().GetItem(EQ::invslot::slotSecondary);
 				} else if (HasTwoHanderEquipped()) {
 					if (RuleB(Combat, BashTwoHanderUseShoulderAC)) {
-						inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotShoulders);
+						inst = GetInv().GetItem(EQ::invslot::slotShoulders);
 					} else {
-						inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
+						inst = GetInv().GetItem(EQ::invslot::slotPrimary);
 					}
 				}
 			}
@@ -164,15 +147,15 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return static_cast<int>(ac_bonus + skill_bonus);
 		}
+
 		case EQ::skills::SkillBackstab: {
 			float skill_bonus = static_cast<float>(skill_level) * 0.02f;
-			base              = 3; // There seems to be a base 3 for NPCs or some how BS w/o weapon?
-			// until we get a better inv system for NPCs they get nerfed!
-			if (IsClient()) {
-				auto *inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
+			base = 3; // Base value for backstab
+
+			if (is_client_or_client_pet) {
+				auto *inst = GetInv().GetItem(EQ::invslot::slotPrimary);
 				if (inst && inst->GetItem()) {
 					if (RuleB(Custom, AdditiveBackstabDamage)) {
 						base = inst->GetItemWeaponDamage(true) + inst->GetItemBackstabDamage(true);
@@ -195,23 +178,21 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 						}
 					}
 				}
-			} else if (IsNPC()) {
+			}
+			else if (IsNPC()) {
 				auto *npc = CastToNPC();
 				base = round((npc->GetMaxDMG() - npc->GetMinDMG()) / RuleR(NPC, NPCBackstabMod));
-				// parses show relatively low BS mods from lots of NPCs, so either their BS skill is super low
-				// or their mod is divided again, this is probably not the right mod, but it's better
-				skill_bonus /= 3.0f;
+				skill_bonus /= 3.0f; // Reduce skill bonus for NPCs
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
 				return static_cast<int>(static_cast<float>(base) * (skill_bonus + 2.0f)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
-
 			return static_cast<int>(static_cast<float>(base) * (skill_bonus + 2.0f));
 		}
-		default: {
+
+		default:
 			return 0;
-		}
 	}
 }
 
@@ -1091,7 +1072,20 @@ void Mob::RogueBackstab(Mob* other, bool min_damage, int ReuseTime)
 				base_damage *= RuleR(Custom, NonDaggerBackstabMultiplier1H);
 			}
 		}
-	} else if (!GetWeaponDamage(other, (const EQ::ItemData*)nullptr)){
+	}
+	else if (IsPetOwnerClient()) {
+		auto weapon = GetInv().GetItem(EQ::invslot::slotPrimary);
+		if (weapon) {
+			base_damage = GetBaseSkillDamage(EQ::skills::SkillBackstab, other);
+			if (weapon->GetItem()->ItemType != EQ::item::ItemType1HPiercing) {
+				base_damage *= RuleR(Custom, NonDaggerBackstabMultiplier1H);
+			}
+		}
+		else {
+			base_damage = GetBaseSkillDamage(EQ::skills::SkillBackstab, other);
+		}
+	}
+	else if (!GetWeaponDamage(other, (const EQ::ItemData*)nullptr)){
 		return;
 	}
 
@@ -2143,6 +2137,8 @@ void NPC::DoClassAttacks(Mob *target) {
 	bool ca_time = classattack_timer.Check(false);
 	bool ka_time = knightattack_timer.Check(false);
 
+	uint16 class_bitmask = Strings::ToUnsignedInt(GetEntityVariable("class_bitmask"), GetPlayerClassBit(GetClass()));
+
 	const EQ::ItemData* boots = database.GetItem(equipment[EQ::invslot::slotFeet]);
 
 	//only check attack allowed if we are going to do something
@@ -2152,22 +2148,18 @@ void NPC::DoClassAttacks(Mob *target) {
 	if(ka_time){
 		int knightreuse = 1000; //lets give it a small cooldown actually.
 
-		switch(GetClass()){
-			case Class::ShadowKnight: case Class::ShadowKnightGM:{
-				if (CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID())) {
-					knightreuse = HarmTouchReuseTime * 1000;
-					}
-				break;
+		if(HasClass(Class::ShadowKnight, class_bitmask) || GetClass() == Class::ShadowKnightGM){
+			if (CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID())) {
+				knightreuse = HarmTouchReuseTime * 1000;
 			}
-			case Class::Paladin: case Class::PaladinGM:{
-				if(GetHPRatio() < 20) {
-					if (CastSpell(SPELL_LAY_ON_HANDS, GetID())) {
-						knightreuse = LayOnHandsReuseTime * 1000;
-					}
-				} else {
-					knightreuse = 2000; //Check again in two seconds.
+		}
+		else if(HasClass(Class::Paladin, class_bitmask) || GetClass() == Class::PaladinGM){
+			if(GetHPRatio() < 20) {
+				if (CastSpell(SPELL_LAY_ON_HANDS, GetID())) {
+					knightreuse = LayOnHandsReuseTime * 1000;
 				}
-				break;
+			} else {
+				knightreuse = 2000; //Check again in two seconds.
 			}
 		}
 		knightattack_timer.Start(knightreuse);
@@ -2221,97 +2213,40 @@ void NPC::DoClassAttacks(Mob *target) {
 	int reuse = TauntReuseTime * 1000;	//make this very long since if they dont use it once, they prolly never will
 	bool did_attack = false;
 	//class specific stuff...
-	switch(GetClass()) {
-		case Class::Rogue: case Class::RogueGM:
-			if(level >= 10) {
-				reuse = BackstabReuseTime * 1000;
-				TryBackstab(target, reuse);
-				did_attack = true;
-			}
-			break;
-		case Class::Monk: case Class::MonkGM: {
-			uint8 satype = EQ::skills::SkillKick;
-			if (level > 29) { satype = EQ::skills::SkillFlyingKick; }
-			else if (level > 24) { satype = EQ::skills::SkillDragonPunch; }
-			else if (level > 19) { satype = EQ::skills::SkillEagleStrike; }
-			else if (level > 9) { satype = EQ::skills::SkillTigerClaw; }
-			else if (level > 4) { satype = EQ::skills::SkillRoundKick; }
-			reuse = MonkSpecialAttack(target, satype);
-
-			reuse *= 1000;
+	if(HasClass(Class::Rogue, class_bitmask) || GetClass() == Class::RogueGM) {
+		if(level >= 10) {
+			reuse = BackstabReuseTime * 1000;
+			TryBackstab(target, reuse);
 			did_attack = true;
-			break;
 		}
-		case Class::Warrior: case Class::WarriorGM:{
-			if(level >= RuleI(Combat, NPCBashKickLevel)){
-				if(zone->random.Roll(75)) { //tested on live, warrior mobs both kick and bash, kick about 75% of the time, casting doesn't seem to make a difference.
-					DoAnim(animKick, 0, false);
-					int64 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
+	}
+	else if(HasClass(Class::Monk, class_bitmask) || GetClass() == Class::MonkGM) {
+		uint8 satype = EQ::skills::SkillKick;
+		if (level > 29) { satype = EQ::skills::SkillFlyingKick; }
+		else if (level > 24) { satype = EQ::skills::SkillDragonPunch; }
+		else if (level > 19) { satype = EQ::skills::SkillEagleStrike; }
+		else if (level > 9) { satype = EQ::skills::SkillTigerClaw; }
+		else if (level > 4) { satype = EQ::skills::SkillRoundKick; }
+		reuse = MonkSpecialAttack(target, satype);
 
-					if (GetWeaponDamage(target, boots) <= 0) {
-						dmg = DMG_INVULNERABLE;
-					}
-
-					reuse = (KickReuseTime + 3) * 1000;
-					DoSpecialAttackDamage(target, EQ::skills::SkillKick, dmg, GetMinDamage(), -1, reuse);
-					did_attack = true;
-				}
-				else {
-					DoAnim(animTailRake, 0, false);
-					int64 dmg = GetBaseSkillDamage(EQ::skills::SkillBash);
-
-					if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
-						dmg = DMG_INVULNERABLE;
-
-					reuse = (BashReuseTime + 3) * 1000;
-					DoSpecialAttackDamage(target, EQ::skills::SkillBash, dmg, GetMinDamage(), -1, reuse);
-					did_attack = true;
-				}
-			}
-			break;
-		}
-		case Class::Berserker: case Class::BerserkerGM:{
-			int AtkRounds = 1;
-			int32 max_dmg = GetBaseSkillDamage(EQ::skills::SkillFrenzy);
-			DoAnim(anim2HSlashing, 0, false);
-
-			if (HasClass(Class::Berserker)) {
-				int chance = GetLevel() * 2 + GetSkill(EQ::skills::SkillFrenzy);
-				if (zone->random.Roll0(450) < chance)
-					AtkRounds++;
-				if (zone->random.Roll0(450) < chance)
-					AtkRounds++;
-			}
-
-			while (AtkRounds > 0) {
-				if (GetTarget())
-					DoSpecialAttackDamage(GetTarget(), EQ::skills::SkillFrenzy, max_dmg, GetMinDamage(), -1, reuse);
-				AtkRounds--;
-			}
-
-			did_attack = true;
-			break;
-		}
-		case Class::Ranger: case Class::RangerGM:
-		case Class::Beastlord: case Class::BeastlordGM: {
-			//kick
-			if(level >= RuleI(Combat, NPCBashKickLevel)){
+		reuse *= 1000;
+		did_attack = true;
+	}
+	else if(HasClass(Class::Warrior, class_bitmask) || GetClass() == Class::WarriorGM) {
+		if(level >= RuleI(Combat, NPCBashKickLevel)){
+			if(zone->random.Roll(75)) { //tested on live, warrior mobs both kick and bash, kick about 75% of the time, casting doesn't seem to make a difference.
 				DoAnim(animKick, 0, false);
 				int64 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
 
-				if (GetWeaponDamage(target, boots) <= 0)
+				if (GetWeaponDamage(target, boots) <= 0) {
 					dmg = DMG_INVULNERABLE;
+				}
 
 				reuse = (KickReuseTime + 3) * 1000;
 				DoSpecialAttackDamage(target, EQ::skills::SkillKick, dmg, GetMinDamage(), -1, reuse);
 				did_attack = true;
 			}
-			break;
-		}
-		case Class::Cleric: case Class::ClericGM: //clerics can bash too.
-		case Class::ShadowKnight: case Class::ShadowKnightGM:
-		case Class::Paladin: case Class::PaladinGM:{
-			if(level >= RuleI(Combat, NPCBashKickLevel)){
+			else {
 				DoAnim(animTailRake, 0, false);
 				int64 dmg = GetBaseSkillDamage(EQ::skills::SkillBash);
 
@@ -2322,7 +2257,57 @@ void NPC::DoClassAttacks(Mob *target) {
 				DoSpecialAttackDamage(target, EQ::skills::SkillBash, dmg, GetMinDamage(), -1, reuse);
 				did_attack = true;
 			}
-			break;
+		}
+	}
+	else if(HasClass(Class::Berserker, class_bitmask) || GetClass() == Class::BerserkerGM) {
+		int AtkRounds = 1;
+		int32 max_dmg = GetBaseSkillDamage(EQ::skills::SkillFrenzy);
+		DoAnim(anim2HSlashing, 0, false);
+
+		if (HasClass(Class::Berserker, class_bitmask)) {
+			int chance = GetLevel() * 2 + GetSkill(EQ::skills::SkillFrenzy);
+			if (zone->random.Roll0(450) < chance)
+				AtkRounds++;
+			if (zone->random.Roll0(450) < chance)
+				AtkRounds++;
+		}
+
+		while (AtkRounds > 0) {
+			if (GetTarget())
+				DoSpecialAttackDamage(GetTarget(), EQ::skills::SkillFrenzy, max_dmg, GetMinDamage(), -1, reuse);
+			AtkRounds--;
+		}
+
+		did_attack = true;
+	}
+	else if(HasClass(Class::Ranger, class_bitmask) || GetClass() == Class::RangerGM ||
+		HasClass(Class::Beastlord, class_bitmask) || GetClass() == Class::BeastlordGM) {
+		//kick
+		if(level >= RuleI(Combat, NPCBashKickLevel)){
+			DoAnim(animKick, 0, false);
+			int64 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
+
+			if (GetWeaponDamage(target, boots) <= 0)
+				dmg = DMG_INVULNERABLE;
+
+			reuse = (KickReuseTime + 3) * 1000;
+			DoSpecialAttackDamage(target, EQ::skills::SkillKick, dmg, GetMinDamage(), -1, reuse);
+			did_attack = true;
+		}
+	}
+	else if(HasClass(Class::Cleric, class_bitmask) || GetClass() == Class::ClericGM || //clerics can bash too.
+		HasClass(Class::ShadowKnight, class_bitmask) || GetClass() == Class::ShadowKnightGM ||
+		HasClass(Class::Paladin, class_bitmask) || GetClass() == Class::PaladinGM) {
+		if(level >= RuleI(Combat, NPCBashKickLevel)){
+			DoAnim(animTailRake, 0, false);
+			int64 dmg = GetBaseSkillDamage(EQ::skills::SkillBash);
+
+			if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
+				dmg = DMG_INVULNERABLE;
+
+			reuse = (BashReuseTime + 3) * 1000;
+			DoSpecialAttackDamage(target, EQ::skills::SkillBash, dmg, GetMinDamage(), -1, reuse);
+			did_attack = true;
 		}
 	}
 

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1367,7 +1367,7 @@ void Mob::DoArcheryAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, co
 
 		DamageHitInfo my_hit {};
 		my_hit.base_damage = MaxDmg;
-		my_hit.min_damage = 0;
+		my_hit.min_damage = GetWeaponDamageBonus(RangeWeapon->GetItem(), false);
 		my_hit.damage_done = 1;
 
 		my_hit.skill = EQ::skills::SkillArchery;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1367,7 +1367,7 @@ void Mob::DoArcheryAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, co
 
 		DamageHitInfo my_hit {};
 		my_hit.base_damage = MaxDmg;
-		my_hit.min_damage = GetWeaponDamageBonus(RangeWeapon->GetItem(), false);
+		my_hit.min_damage = RangeWeapon ? GetWeaponDamageBonus(RangeWeapon->GetItem(), false) : 0;
 		my_hit.damage_done = 1;
 
 		my_hit.skill = EQ::skills::SkillArchery;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -385,7 +385,50 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 	}
 
 	TryCastOnSkillUse(who, skill);
-
+  if (my_hit.critical == 4) {
+    entity_list.FilteredMessageClose(
+      this,
+      false,
+		  RuleI(Range, CriticalDamage),
+			Chat::MeleeCrit, /* Type: 301 */
+			FilterMeleeCrits, /* FilterType: 12 */
+      "%s lands a Cleaving Blow! (%i)",
+      GetCleanName(),
+      my_hit.damage_done
+    );
+  }
+  else if (my_hit.critical >= 1 && my_hit.critical != 4) {
+    int critType;
+    int dmg;
+    if (my_hit.critical == 1) { /* Crippling Blow */
+      critType = CRITICAL_HIT;
+      dmg = my_hit.damage_done;
+    }
+    else if (my_hit.critical == 2) { /* Crippling Blow */
+      critType = CRIPPLING_BLOW;
+      dmg = my_hit.damage_done;
+    }
+    else if (my_hit.critical == 3) { /* Slay Undead */
+      int slay_sex = GetGender() == Gender::Female ? FEMALE_SLAYUNDEAD : MALE_SLAYUNDEAD;
+      critType = slay_sex;
+      dmg = my_hit.damage_done;
+    }
+    else if (my_hit.critical == 5) { /* Deadly Strike */
+      critType = DEADLY_STRIKE;
+      dmg = my_hit.damage_done + my_hit.min_damage;
+    }
+		entity_list.FilteredMessageCloseString(
+		  this, /* Sender */
+			false, /* Skip Sender */
+			RuleI(Range, CriticalDamage),
+			Chat::MeleeCrit, /* Type: 301 */
+			FilterMeleeCrits, /* FilterType: 12 */
+			critType, 
+			0,
+			GetCleanName(), /* Message1 */
+			itoa(dmg) /* Message2 */
+		);
+	}
 	if (HasSkillProcs()) {
 		TrySkillProc(who, skill, ReuseTime * 1000);
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4187,6 +4187,8 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 				caster->ResourceTap(-effect_value, buff.spellid);
 				effect_value = -effect_value;
 				Damage(caster, effect_value, buff.spellid, spell.skill, false, i, true);
+
+				caster->TrySympatheticProc(this, buff.spellid);
 			} else if (effect_value > 0) {
 				// Regen spell...
 				// handled with bonuses
@@ -4986,7 +4988,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 	// notify caster (or their master) of buff that it's worn off
 	Mob *p = entity_list.GetMob(buffs[slot].casterid);
-	if (p && p != this && !IsBardSong(buffs[slot].spellid))
+	if (!EntityVariableExists("suppress_wornoff") && p && p != this && !IsBardSong(buffs[slot].spellid))
 	{
 		Mob *notify = p;
 		if(p->IsPet())
@@ -6954,6 +6956,8 @@ uint16 Mob::GetSympatheticFocusEffect(focusType type, uint16 spell_id) {
 			if (SympatheticProcList.size() > MAX_SYMPATHETIC_PROCS) {
 				break;
 			}
+
+			LogDebug("Check");
 
 			auto ability_rank = zone->GetAlternateAdvancementAbilityAndRank(aa.first, aa.second.first);
 			auto ability = ability_rank.first;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3561,6 +3561,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_InvisVsUndead2:
 			case SE_Shield_Target:
 			case SE_ReduceSkill:
+			case SE_PersistantCasting:
 			{
 				break;
 			}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6710,6 +6710,10 @@ bool Mob::IsCombatProc(uint16 spell_id) {
 		return false;
 	}
 
+	if (GetEntityVariable("ProcHint") == "true") {
+		return true;
+	}
+
 	if (!IsValidSpell(spell_id)) {
 		return(false);
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1397,6 +1397,7 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	}
 
 	ZeroCastingVars();	// resets all the state keeping stuff
+	DeleteEntityVariable(fmt::format("SpellGemHint_%d", spellid));
 
 	LogSpells("Spell [{}] has been interrupted", spellid);
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3985,7 +3985,13 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 				if (IsCharmSpell(spell_id)) {
 					SetEntityVariable("preserve_inventory", "true");
 				}
+
+				if (buffs[*cur].spellid == spell_id) {
+					SetEntityVariable("suppress_wornoff", "true");
+				}
 				BuffFadeBySlot(*cur, false);
+				DeleteEntityVariable("suppress_wornoff");
+
 			}
 
 			// if we hadn't found a free slot before, or if this is earlier

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1651,7 +1651,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 
 			// as you get farther from your casting location,
 			// it gets squarely harder to regain concentration
-			if(GetX() != GetSpellX() || GetY() != GetSpellY())
+			if((GetX() != GetSpellX() || GetY() != GetSpellY()) && channelchance < 100)
 			{
 				d_x = std::abs(std::abs(GetX()) - std::abs(GetSpellX()));
 				d_y = std::abs(std::abs(GetY()) - std::abs(GetSpellY()));


### PR DESCRIPTION
# Description

Fix melee critical hit messages on both auto attack and skills to match the actual damage being done.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

* Tested auto-attack critical hits to be accurate
* Tested skill critical hits to be accurate
* Tested Frenzy cleaving blow to be accurate
* Tested Slay Undead to be accurate
* Tested Deadly Throw, could not reproduce a critical hit?
* Tested Archery, could not reproduce a critical hit?

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X ] I own the changes of my code and take responsibility for the potential issues that occur
