### PR TITLE
Adjust crit message locations

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1541,7 +1541,6 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 			LogCombat("Attack missed. Damage set to 0");
 			hit.damage_done = 0;
 		}
-
 		parse->EventBotMerc(EVENT_USE_SKILL, this, nullptr,
 			[&]() {
 				return fmt::format(
@@ -1762,7 +1761,7 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	MeleeLifeTap(my_hit.damage_done);
 
 	CommonBreakInvisibleFromCombat();
-
+	ReportCriticalHit(my_hit);
 	if (GetTarget()) {
 		TriggerDefensiveProcs(other, Hand, true, my_hit.damage_done);
 	}
@@ -6791,7 +6790,6 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 		}
 	}
 
-	ReportCriticalHit(hit);
 	CheckNumHitsRemaining(NumHit::OutgoingHitSuccess);
 }
 

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -385,7 +385,7 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 	}
 
 	TryCastOnSkillUse(who, skill);
-
+	ReportCriticalHit(my_hit);
 	if (HasSkillProcs()) {
 		TrySkillProc(who, skill, ReuseTime * 1000);
 	}
@@ -1376,6 +1376,7 @@ void Mob::DoArcheryAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, co
 		my_hit.hand = EQ::invslot::slotRange;
 
 		DoAttack(other, my_hit);
+		ReportCriticalHit(my_hit);
 		TotalDmg = my_hit.damage_done;
 	} else {
 		TotalDmg = DMG_INVULNERABLE;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1953,9 +1953,8 @@ void Mob::DoThrowingAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, c
 	}
 
 	int64 TotalDmg = 0;
-
+	DamageHitInfo my_hit {};
 	if (WDmg > 0) {
-		DamageHitInfo my_hit {};
 		my_hit.base_damage = WDmg;
 		my_hit.min_damage = 0;
 		my_hit.damage_done = 1;
@@ -1982,6 +1981,7 @@ void Mob::DoThrowingAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, c
 		TotalDmg = (WDmg + GetHeroicSTR() + GetHeroicDEX());
 	}
 
+	ReportCriticalHit(my_hit);
 	MeleeLifeTap(TotalDmg);
 	other->Damage(this, TotalDmg, SPELL_UNKNOWN, EQ::skills::SkillThrowing);
 
@@ -2010,7 +2010,6 @@ void Mob::DoThrowingAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, c
 			}
 		}
 	}
-
 	if (IsClient()) {
 		CastToClient()->CheckIncreaseSkill(EQ::skills::SkillThrowing, GetTarget());
 


### PR DESCRIPTION
# Description

Fixes critical strike messages to be accurate, even taking into account the new rule regarding heroic strength and melee attacks.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

* Tested Ranged Crits:
![image](https://github.com/user-attachments/assets/baf047a1-6b7a-429b-801b-a493831ffc73)

* Tested Melee Crits:
![image](https://github.com/user-attachments/assets/c2d3f26a-b9ea-40aa-b1ea-72ba3d36580b)

* Tested Skill Crits:
![image](https://github.com/user-attachments/assets/b4e3be33-d832-4c09-a881-97281508d57a)

* Tested Crippling Blow:
![image](https://github.com/user-attachments/assets/9ed8cfe7-c5b1-4640-9014-8be7671c2b73)

* Tested Cleaving Blow:
![image](https://github.com/user-attachments/assets/9eedbbc0-42d0-45db-bdeb-1fd180aa13ff)

* Tested Slay Undead:
![image](https://github.com/user-attachments/assets/65183ba1-7c3f-46c6-9eef-be186c9f4377)

Clients tested: THJ Client (5/18/2025)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
