### PR TITLE
Suppress 'Ability recovery time not yet met.' when using attackmode ranged.

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -535,7 +535,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 
 	if (!p_timers.Expired(&database, timer, false) && !is_riposte) {
 		if (!EntityVariableExists("auto_skill")) {
-			Message(Chat::Red, "Ability recovery time not yet met. ({}, {}, {})", ca_atk->m_skill, ca_atk->m_target, ca_atk->m_atk);
+			Message(Chat::Red, fmt::format("Ability recovery time not yet met. ({}, {}, {})", ca_atk->m_skill, ca_atk->m_target, ca_atk->m_atk).c_str());
 		}
 		return;
 	}

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -495,9 +495,6 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 	// allready do their checking in conjunction with the attack timer
 	// throwing weapons
 	if (ca_atk->m_atk == EQ::invslot::slotRange && ranged_timer.Check(false)) {
-		if (GetAttackMode() == AttackMode::RANGED) {
-			return;
-		}
 		if (ca_atk->m_skill == EQ::skills::SkillThrowing) {
 			SetAttackTimer();
 			ThrowingAttack(GetTarget());
@@ -528,6 +525,10 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 		}
 	}
 
+	if (ca_atk->m_atk == EQ::invslot::slotRange && GetAttackMode() == AttackMode::RANGED && (AutoAttackEnabled() || AutoFireEnabled())) {
+		return;
+	}
+
 	// check range for all these abilities, they are all close combat stuff
 	if (!CombatRange(GetTarget())) {
 		return;
@@ -535,7 +536,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 
 	if (!p_timers.Expired(&database, timer, false) && !is_riposte) {
 		if (!EntityVariableExists("auto_skill")) {
-			Message(Chat::Red, fmt::format("Ability recovery time not yet met. ({}, {}, {})", ca_atk->m_skill, ca_atk->m_target, ca_atk->m_atk).c_str());
+			Message(Chat::Red, "Ability recovery time not yet met");
 		}
 		return;
 	}

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -535,7 +535,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 
 	if (!p_timers.Expired(&database, timer, false) && !is_riposte) {
 		if (!EntityVariableExists("auto_skill")) {
-			Message(Chat::Red, "Ability recovery time not yet met.");
+			Message(Chat::Red, "Ability recovery time not yet met. ({}, {}, {})", ca_atk->m_skill, ca_atk->m_target, ca_atk->m_atk);
 		}
 		return;
 	}
@@ -1061,7 +1061,7 @@ int Mob::GetWeaponBackstabDamage(EQ::ItemInstance* inst, Mob *target) {
 				base += target->CheckBaneDamage(inst);
 			}
 		}
-	}	
+	}
 	if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(EQ::skills::SkillBackstab) > 0) {
 		return static_cast<int>(static_cast<float>(base) * (skill_bonus + 2.0f)) * std::abs(GetSkillDmgAmt(EQ::skills::SkillBackstab) / 100);
 	}

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -536,7 +536,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk, bool is_riposte
 
 	if (!p_timers.Expired(&database, timer, false) && !is_riposte) {
 		if (!EntityVariableExists("auto_skill")) {
-			Message(Chat::Red, "Ability recovery time not yet met");
+			Message(Chat::Red, "Ability recovery time not yet met.");
 		}
 		return;
 	}


### PR DESCRIPTION
# Description

See title

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: 

# Checklist

- [ ] I have tested my changes
- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
