### PR TITLE
Allow short duration buffs to overflow into regular buff slots

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -486,7 +486,7 @@ public:
 	void BuffDetachCaster(Mob *caster);
 	bool IsAffectedByBuffByGlobalGroup(GlobalGroup group);
 	void BuffModifyDurationBySpellID(uint16 spell_id, int32 newDuration);
-	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overwrite = false);
+	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overwrite = false, bool override_short_duration = false);
 	int CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite = false);
 	int CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caster_level_override = -1);
 	void SendPetBuffsToClient();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3894,7 +3894,7 @@ bool Mob::HasDiscBuff()
 // stacking problems, and -2 if this is not a buff
 // if caster is null, the buff will be added with the caster level being
 // the level of the mob
-int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override, bool disable_buff_overwrite)
+int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override, bool disable_buff_overwrite, bool override_short_duration)
 {
 	int buffslot, ret, caster_level, emptyslot = -1;
 	bool will_overwrite = false;
@@ -3926,8 +3926,18 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 	// we also check if overwriting will occur. this is so after this loop
 	// we can determine if there will be room for this buff
 	int buff_count = GetMaxTotalSlots();
-	uint32 start_slot = GetFirstBuffSlot(IsDisciplineBuff(spell_id), spells[spell_id].short_buff_box);
-	uint32 end_slot = GetLastBuffSlot(IsDisciplineBuff(spell_id), spells[spell_id].short_buff_box);
+	uint32 start_slot;
+	uint32 end_slot;
+	if (override_short_duration) {
+		start_slot = GetFirstBuffSlot(IsDisciplineBuff(spell_id), false);
+	} else {
+		start_slot = GetFirstBuffSlot(IsDisciplineBuff(spell_id), spells[spell_id].short_buff_box);
+	}
+	if (override_short_duration) {
+		end_slot = GetLastBuffSlot(IsDisciplineBuff(spell_id), false);
+	} else {
+		end_slot = GetLastBuffSlot(IsDisciplineBuff(spell_id), spells[spell_id].short_buff_box);
+	}
 
 	for (buffslot = 0; buffslot < buff_count; buffslot++) {
 		const Buffs_Struct &curbuf = buffs[buffslot];
@@ -4063,8 +4073,15 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 				return -1;
 			}
 		} else {
-			LogSpells("Unable to find a buff slot for beneficial buff [{}]", spell_id);
-			return -1;
+			// If this is a short duration buff, try again in the regular buff slots.
+			if (spells[spell_id].short_buff_box && !override_short_duration) {
+				LogSpells("Unable to find a buff slot for beneficial buff [{}] but it's short duration, trying regular buff slots.",
+					spell_id);
+				return AddBuff(caster, spell_id, duration, level_override, disable_buff_overwrite, true);
+			} else {
+				LogSpells("Unable to find a buff slot for beneficial buff [{}]", spell_id);
+				return -1;
+			}
 		}
 	}
 	//do not fade buff if from bard pulse, live does not give a fades message.


### PR DESCRIPTION
# Description

Allows short duration buffs (songs, burst AAs, etc) to use regular buff slots if there are already the maximum number of short duration buffs on the character.

This will NOT allow regular/long duration buffs to overflow into the short duration window, and if all buff slots (both short and long duration) are filled, the new buff is blocked.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
* Tested filling the short duration buff window with maximum (currently 20) short duration buffs, then trying to apply a new short duration buff.
  * The new short duration buff went into the regular/long duration buff bar
* Tested filling the short duration buff window and the regular duration buff window with maximum (20 and 40 respectively) buffs then tried to apply both a long duration and short duration buff
  * In both cases, the new buff was not applied.
* Tested filling the regular duration buff window with maximum buffs then trying to cast a regular/long duration buff.
  * The buff was not applied (in either long or short duration window).

Clients tested: THJ Client

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
